### PR TITLE
Release 0.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version:5.3
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
@@ -12,19 +11,14 @@ let package = Package(
         .watchOS(.v6)
     ],
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "AmuseKit",
             targets: ["AmuseKit"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "3.0.0"),
+        .package(url: "https://github.com/kishikawakatsumi/KeychainAccess.git", from: "4.0.0"),
     ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "AmuseKit",
             dependencies: ["KeychainAccess"]),

--- a/README.md
+++ b/README.md
@@ -32,21 +32,85 @@ amuseProvider.setUserToken("USER_TOKEN")
 amuseProvider.setUserCountryCode("USER_COUNTRY_CODE")
 ```
 
-
-### Retrieve All User's Library Playlists.
+### Retrieve multiple Albums from Apple Music catalog by ids.
 
 ```swift
-amuseProvider.libraryPlaylists()
+amuseProvider.catalog(.albums, ids: ["123", "456", "789"])
     .sink { _ in
     } receiveValue: { response in
         print(response.data)
     }
 ```
 
+### Retrieve multiple Artists from Apple Music catalog by ids.
+
+```swift
+amuseProvider.catalog(.artists, ids: ["123", "456", "789"])
+    .sink { _ in
+    } receiveValue: { response in
+        print(response.data)
+    }
+```
+
+### Retrieve multiple Music Videos from Apple Music catalog by ids.
+
+```swift
+amuseProvider.catalog(.musicVideos, ids: ["123", "456", "789"])
+    .sink { _ in
+    } receiveValue: { response in
+        print(response.data)
+    }
+```
+
+### Retrieve multiple Playlists from Apple Music catalog by ids.
+
+```swift
+amuseProvider.catalog(.playlists, ids: ["123", "456", "789"])
+    .sink { _ in
+    } receiveValue: { response in
+        print(response.data)
+    }
+```
+
+### Retrieve multiple Songs from Apple Music catalog by ids.
+
+```swift
+amuseProvider.catalog(.songs, ids: ["123", "456", "789"])
+    .sink { _ in
+    } receiveValue: { response in
+        print(response.data)
+    }
+```
+
+### Search on Apple Music catalog.
+
+```swift
+amuseProvider.catalogSearch(searchTerm: "YOUR_QUERY_TEXT")
+    .sink { _ in
+    } receiveValue: { response in
+        // content will be found under results properties.
+        print(response.results?.albums)
+        print(response.results?.artists)
+        print(response.results?.playlists)
+        print(response.results?.songs)
+    }
+```
+
+### Search on Apple Music catalog for specific types.
+
+```swift
+amuseProvider.catalogSearch([.playlists, .songs], searchTerm: "YOUR_QUERY_TEXT")
+    .sink { _ in
+    } receiveValue: { response in
+        print(response.results?.playlists)
+        print(response.results?.songs)
+    }
+```
+
 ### Retrieve All User's Library Albums.
 
 ```swift
-amuseProvider.libraryAlbums()
+amuseProvider.library(.albums)
     .sink { _ in
     } receiveValue: { response in
         print(response.data)
@@ -56,17 +120,7 @@ amuseProvider.libraryAlbums()
 ### Retrieve All User's Library Artists.
 
 ```swift
-amuseProvider.libraryArtists()
-    .sink { _ in
-    } receiveValue: { response in
-        print(response.data)
-    }
-```
-
-### Retrieve All User's Library Songs.
-
-```swift
-amuseProvider.librarySongs()
+amuseProvider.library(.artists)
     .sink { _ in
     } receiveValue: { response in
         print(response.data)
@@ -76,7 +130,27 @@ amuseProvider.librarySongs()
 ### Retrieve All User Library Music Videos.
 
 ```swift
-amuseProvider.libraryMusicVideos()
+amuseProvider.library(.musicVideos)
+    .sink { _ in
+    } receiveValue: { response in
+        print(response.data)
+    }
+```
+
+### Retrieve All User's Library Playlists.
+
+```swift
+amuseProvider.library(.playlists)
+    .sink { _ in
+    } receiveValue: { response in
+        print(response.data)
+    }
+```
+
+### Retrieve All User's Library Songs.
+
+```swift
+amuseProvider.library(.songs)
     .sink { _ in
     } receiveValue: { response in
         print(response.data)
@@ -101,31 +175,6 @@ amuseProvider.librarySearch(searchTerm: "YOUR_QUERY_TEXT")
 
 ```swift
 amuseProvider.librarySearch([.playlists, .songs], searchTerm: "YOUR_QUERY_TEXT")
-    .sink { _ in
-    } receiveValue: { response in
-        print(response.results?.playlists)
-        print(response.results?.songs)
-    }
-```
-
-### Search on Apple Music catalog.
-
-```swift
-amuseProvider.catalogSearch(searchTerm: "YOUR_QUERY_TEXT")
-    .sink { _ in
-    } receiveValue: { response in
-        // content will be found under results properties.
-        print(response.results?.albums)
-        print(response.results?.artists)
-        print(response.results?.playlists)
-        print(response.results?.songs)
-    }
-```
-
-### Search on Apple Music catalog for specific types.
-
-```swift
-amuseProvider.catalogSearch([.playlists, .songs], searchTerm: "YOUR_QUERY_TEXT")
     .sink { _ in
     } receiveValue: { response in
         print(response.results?.playlists)

--- a/Sources/AmuseKit/Models/Resource.swift
+++ b/Sources/AmuseKit/Models/Resource.swift
@@ -10,7 +10,7 @@ import Foundation
 // A resource—such as an album, song, or playlist—in the Apple Music catalog or iCloud Music Library.
 // https://developer.apple.com/documentation/applemusicapi/resource
 
-public protocol Resource: Codable {
+protocol Resource: Codable {
     associatedtype Attributes
     associatedtype Relationships
     var attributes: Attributes? { get }

--- a/Sources/AmuseKit/Models/Resources/Catalog/Album.swift
+++ b/Sources/AmuseKit/Models/Resources/Catalog/Album.swift
@@ -30,7 +30,6 @@ public extension AmuseKit.Album {
 
     struct Attributes: Codable {
         public let artistName: String
-        public let albumName: String?
         public let artwork: AmuseKit.Artwork
         public let contentRating: String?
         public let copyright: String?

--- a/Sources/AmuseKit/Models/Resources/Catalog/Song.swift
+++ b/Sources/AmuseKit/Models/Resources/Catalog/Song.swift
@@ -10,7 +10,7 @@ import Foundation
 public extension AmuseKit {
     
     /// A resource object that represents a song.
-    /// https://developer.apple.com/documentation/applemusicapi/songs-um8.
+    /// https://developer.apple.com/documentation/applemusicapi/songs
     /// Latest revision Feb 21 2022.
 
     struct Song: Resource {

--- a/Sources/AmuseKit/Networking/DataProvider.swift
+++ b/Sources/AmuseKit/Networking/DataProvider.swift
@@ -8,19 +8,9 @@
 import Combine
 import Foundation
 import class KeychainAccess.Keychain
+import AppKit
 
 public extension AmuseKit {
-    typealias CatalogPlaylistResponse = ResponseRoot<Playlist, EmptyCodable>
-    typealias CatalogAlbumResponse = ResponseRoot<Album, EmptyCodable>
-    typealias CatalogArtistResponse = ResponseRoot<Artist, EmptyCodable>
-    typealias CatalogSongResponse = ResponseRoot<Song, EmptyCodable>
-    typealias CatalogMusicVideoResponse = ResponseRoot<MusicVideo, EmptyCodable>
-    
-    typealias LibraryPlaylistResponse = ResponseRoot<LibraryPlaylist, EmptyCodable>
-    typealias LibraryAlbumResponse = ResponseRoot<LibraryAlbum, EmptyCodable>
-    typealias LibraryArtistResponse = ResponseRoot<LibraryArtist, EmptyCodable>
-    typealias LibrarySongResponse = ResponseRoot<LibrarySong, EmptyCodable>
-    typealias LibraryMusicVideoResponse = ResponseRoot<LibraryMusicVideo, EmptyCodable>
     
     class DataProvider {
         public typealias CatalogSearchTypes = Set<CatalogResourceType>
@@ -58,79 +48,42 @@ public extension AmuseKit {
         
         // MARK: - Catalog Methods
         
-        public func catalogPlaylists(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogPlaylistResponse, Error> {
-            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .playlists), ids: ids)
-        }
-        
-        public func catalogAlbums(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogAlbumResponse, Error> {
-            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .albums), ids: ids)
-        }
-        
-        public func catalogArtists(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogArtistResponse, Error> {
-            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .artists), ids: ids)
-        }
-        
-        public func catalogSongs(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogSongResponse, Error> {
-            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .songs), ids: ids)
-        }
-        
-        public func catalogMusicVideos(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogMusicVideoResponse, Error> {
-            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .musicVideos), ids: ids)
-        }
-        
-        private func catalogRequest<T: Codable>(_ router: Router, ids: [String]) throws -> AnyPublisher<T, Error> {
+        func catalog<Resource: Codable>(_ resourceType: CatalogResourceConvertible<Resource>, ids: [String]) throws -> AnyPublisher<AmuseKit.ResponseRoot<Resource, EmptyCodable>, Error> {
             guard let developerToken = storage.developerToken else {
                 throw AmuseKit.AmuseError.missingDevToken
             }
 
-            var request = try router.asURLRequest([.init(name: "ids", value: ids.joined(separator: ","))])
+            var request = try Router.catalog(countryCode: userCountryCode, resourceType: resourceType.rawValue).asURLRequest(
+                [.init(name: "ids", value: ids.joined(separator: ","))]
+            )
             request.setValue("Bearer \(developerToken)", forHTTPHeaderField: "Authorization")
             request.setValue(storage.userToken, forHTTPHeaderField: "Music-User-Token")
             return try service.publisher(with: request)
+        }
+        
+        public func catalogSearch(_ resourceTypes: CatalogSearchTypes = .all, limit: Int = 25, searchTerm: String) throws -> AnyPublisher<AmuseKit.SearchResponse, Error> {
+            try searchRequest(.search(countryCode: userCountryCode), rawTypes: resourceTypes.map({ $0.rawValue }), limit: limit, searchTerm: searchTerm)
         }
 
         // MARK: - Library Methods
-
-        public func libraryPlaylists() throws -> AnyPublisher<AmuseKit.LibraryPlaylistResponse, Error> {
-            try libraryRequest(.library(.playlists))
-        }
-
-        public func libraryAlbums() throws -> AnyPublisher<AmuseKit.LibraryAlbumResponse, Error> {
-            try libraryRequest(.library(.albums))
-        }
         
-        public func libraryArtists() throws -> AnyPublisher<AmuseKit.LibraryArtistResponse, Error> {
-            try libraryRequest(.library(.artists))
-        }
-        
-        public func librarySongs() throws -> AnyPublisher<AmuseKit.LibrarySongResponse, Error> {
-            try libraryRequest(.library(.songs))
-        }
-        
-        public func libraryMusicVideos() throws -> AnyPublisher<AmuseKit.LibraryMusicVideoResponse, Error> {
-            try libraryRequest(.library(.musicVideos))
-        }
-        
-        private func libraryRequest<T: Codable>(_ router: Router) throws -> AnyPublisher<T, Error> {
+        func library<Resource: Codable>(_ resourceType: LibraryResourceConvertible<Resource>) throws -> AnyPublisher<AmuseKit.ResponseRoot<Resource, EmptyCodable>, Error> {
             guard let developerToken = storage.developerToken else {
                 throw AmuseKit.AmuseError.missingDevToken
             }
 
-            var request = try router.asURLRequest([])
+            var request = try Router.library(resourceType.rawValue).asURLRequest([])
             request.setValue("Bearer \(developerToken)", forHTTPHeaderField: "Authorization")
             request.setValue(storage.userToken, forHTTPHeaderField: "Music-User-Token")
             return try service.publisher(with: request)
         }
         
-        // MARK: - Search Methods
 
         public func librarySearch(_ resourceTypes: LibrarySearchTypes = .all, limit: Int = 25, searchTerm: String) throws -> AnyPublisher<AmuseKit.LibrarySearchResponse, Error> {
             try searchRequest(.librarySearch, rawTypes: resourceTypes.map({ $0.rawValue }), limit: limit, searchTerm: searchTerm)
         }
-
-        public func catalogSearch(_ resourceTypes: CatalogSearchTypes = .all, limit: Int = 25, searchTerm: String) throws -> AnyPublisher<AmuseKit.SearchResponse, Error> {
-            try searchRequest(.search(countryCode: userCountryCode), rawTypes: resourceTypes.map({ $0.rawValue }), limit: limit, searchTerm: searchTerm)
-        }
+        
+        // MARK: - Private Methods
         
         private func searchRequest<T: Codable>(_ router: Router, rawTypes: [String], limit: Int, searchTerm: String) throws -> AnyPublisher<T, Error> {
             guard let developerToken = storage.developerToken else {
@@ -146,33 +99,5 @@ public extension AmuseKit {
             request.setValue("Bearer \(developerToken)", forHTTPHeaderField: "Authorization")
             return try service.publisher(with: request)
         }
-    }
-}
-
-public extension AmuseKit {
-    enum CatalogResourceType: String, AmuseOption {
-        case albums, artists, curators, playlists, songs, stations
-        case appleCurators = "apple-curators"
-        case musicVideos = "music-videos"
-    }
-
-    enum LibraryResourceType: String, AmuseOption {
-        case albums = "library-albums"
-        case artists = "library-artists"
-        case musicVideos = "library-music-videos"
-        case playlists = "library-playlists"
-        case songs = "library-songs"
-    }
-}
-
-public extension Set where Element == AmuseKit.CatalogResourceType {
-    static var all: Set<Element> {
-        return Set(Element.allCases)
-    }
-}
-
-public extension Set where Element == AmuseKit.LibraryResourceType {
-    static var all: Set<Element> {
-        return Set(Element.allCases)
     }
 }

--- a/Sources/AmuseKit/Networking/DataProvider.swift
+++ b/Sources/AmuseKit/Networking/DataProvider.swift
@@ -10,6 +10,12 @@ import Foundation
 import class KeychainAccess.Keychain
 
 public extension AmuseKit {
+    typealias CatalogPlaylistResponse = ResponseRoot<Playlist, EmptyCodable>
+    typealias CatalogAlbumResponse = ResponseRoot<Album, EmptyCodable>
+    typealias CatalogArtistResponse = ResponseRoot<Artist, EmptyCodable>
+    typealias CatalogSongResponse = ResponseRoot<Song, EmptyCodable>
+    typealias CatalogMusicVideoResponse = ResponseRoot<MusicVideo, EmptyCodable>
+    
     typealias LibraryPlaylistResponse = ResponseRoot<LibraryPlaylist, EmptyCodable>
     typealias LibraryAlbumResponse = ResponseRoot<LibraryAlbum, EmptyCodable>
     typealias LibraryArtistResponse = ResponseRoot<LibraryArtist, EmptyCodable>
@@ -48,6 +54,39 @@ public extension AmuseKit {
         
         public func setUserCountryCode(_ userCountryCode: String) {
             self.userCountryCode = userCountryCode
+        }
+        
+        // MARK: - Catalog Methods
+        
+        public func catalogPlaylists(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogPlaylistResponse, Error> {
+            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .playlists), ids: ids)
+        }
+        
+        public func catalogAlbums(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogAlbumResponse, Error> {
+            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .albums), ids: ids)
+        }
+        
+        public func catalogArtists(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogArtistResponse, Error> {
+            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .artists), ids: ids)
+        }
+        
+        public func catalogSongs(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogSongResponse, Error> {
+            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .songs), ids: ids)
+        }
+        
+        public func catalogMusicVideos(ids: [String]) throws -> AnyPublisher<AmuseKit.CatalogMusicVideoResponse, Error> {
+            try catalogRequest(.catalog(countryCode: userCountryCode, resourceType: .musicVideos), ids: ids)
+        }
+        
+        private func catalogRequest<T: Codable>(_ router: Router, ids: [String]) throws -> AnyPublisher<T, Error> {
+            guard let developerToken = storage.developerToken else {
+                throw AmuseKit.AmuseError.missingDevToken
+            }
+
+            var request = try router.asURLRequest([.init(name: "ids", value: ids.joined(separator: ","))])
+            request.setValue("Bearer \(developerToken)", forHTTPHeaderField: "Authorization")
+            request.setValue(storage.userToken, forHTTPHeaderField: "Music-User-Token")
+            return try service.publisher(with: request)
         }
 
         // MARK: - Library Methods

--- a/Sources/AmuseKit/Networking/ResourceConvertible.swift
+++ b/Sources/AmuseKit/Networking/ResourceConvertible.swift
@@ -1,0 +1,98 @@
+//
+//  ResourceConvertible.swift
+//  AmuseKit
+//
+//  Created by Jota Uribe on 12/07/22.
+//
+
+import Foundation
+
+
+/// Allow to associate generic 'Resources' to retrieve them properly parsed from Apple Music Api using DataProvider.
+protocol ResourceConvertible {
+    associatedtype Resource
+}
+
+// MARK: - LibraryResourceConvertible
+
+public extension AmuseKit {
+    enum LibraryResourceType: String, AmuseOption {
+        case albums = "library-albums"
+        case artists = "library-artists"
+        case musicVideos = "library-music-videos"
+        case playlists = "library-playlists"
+        case songs = "library-songs"
+    }
+    
+    struct LibraryResourceConvertible<Model>: ResourceConvertible {
+        typealias Resource = Model
+        let rawValue: LibraryResourceType
+    }
+}
+
+extension AmuseKit.LibraryResourceConvertible where Model == AmuseKit.LibraryAlbum {
+    static var albums = Self.init(rawValue: .albums)
+}
+
+extension AmuseKit.LibraryResourceConvertible where Model == AmuseKit.LibraryArtist {
+    static var artists = Self.init(rawValue: .artists)
+}
+
+extension AmuseKit.LibraryResourceConvertible where Model == AmuseKit.LibraryMusicVideo {
+    static var musicVideos = Self.init(rawValue: .musicVideos)
+}
+
+extension AmuseKit.LibraryResourceConvertible where Model == AmuseKit.LibraryPlaylist {
+    static var playlists = Self.init(rawValue: .playlists)
+}
+
+extension AmuseKit.LibraryResourceConvertible where Model == AmuseKit.LibrarySong {
+    static var songs = Self.init(rawValue: .songs)
+}
+
+public extension Set where Element == AmuseKit.LibraryResourceType {
+    static var all: Set<Element> {
+        return Set(Element.allCases)
+    }
+}
+
+// MARK: - CatalogResourceConvertible
+
+public extension AmuseKit {
+    enum CatalogResourceType: String, AmuseOption {
+        case albums, artists, curators, playlists, songs, stations
+        case appleCurators = "apple-curators"
+        case musicVideos = "music-videos"
+    }
+    
+    struct CatalogResourceConvertible<Model>: ResourceConvertible {
+        typealias Resource = Model
+        let rawValue: CatalogResourceType
+    }
+}
+
+extension AmuseKit.CatalogResourceConvertible where Model == AmuseKit.Album {
+    static var albums = Self.init(rawValue: .albums)
+}
+
+extension AmuseKit.CatalogResourceConvertible where Model == AmuseKit.Artist {
+    static var artists = Self.init(rawValue: .artists)
+}
+
+extension AmuseKit.CatalogResourceConvertible where Model == AmuseKit.MusicVideo {
+    static var musicVideos = Self.init(rawValue: .musicVideos)
+}
+
+extension AmuseKit.CatalogResourceConvertible where Model == AmuseKit.Playlist {
+    static var playlists = Self.init(rawValue: .playlists)
+}
+
+extension AmuseKit.CatalogResourceConvertible where Model == AmuseKit.Song {
+    static var songs = Self.init(rawValue: .songs)
+}
+
+public extension Set where Element == AmuseKit.CatalogResourceType {
+    static var all: Set<Element> {
+        return Set(Element.allCases)
+    }
+}

--- a/Sources/AmuseKit/Networking/Router.swift
+++ b/Sources/AmuseKit/Networking/Router.swift
@@ -17,6 +17,7 @@ protocol URLRequestConvertible {
 
 extension AmuseKit {
     enum Router {
+        case catalog(countryCode: String, resourceType: CatalogResourceType)
         case library(LibraryResourceType)
         case recommendations
         case search(countryCode: String)
@@ -27,6 +28,8 @@ extension AmuseKit {
 extension AmuseKit.Router: URLConvertible, URLRequestConvertible {
     private var path: String {
         switch self {
+        case .catalog(let countryCode, let resourceType):
+            return "/v1/catalog/\(countryCode)/search/\(resourceType)"
         case .library(let type):
             return "/v1/me/\(type.lastPathComponent)"
         case .recommendations:

--- a/Tests/AmuseKitTests/DataModels/Catalog/catalog_albums.json
+++ b/Tests/AmuseKitTests/DataModels/Catalog/catalog_albums.json
@@ -1,0 +1,1224 @@
+{
+    "data": [
+      {
+        "id": "1564530719",
+        "type": "albums",
+        "href": "/v1/catalog/us/albums/1564530719",
+        "attributes": {
+          "artwork": {
+            "width": 3000,
+            "height": 3000,
+            "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+            "bgColor": "6d4d3a",
+            "textColor1": "fcfbf9",
+            "textColor2": "ead3b5",
+            "textColor3": "e0d8d3",
+            "textColor4": "d1b89c"
+          },
+          "artistName": "Billie Eilish",
+          "isSingle": false,
+          "url": "https://music.apple.com/us/album/happier-than-ever/1564530719",
+          "isComplete": true,
+          "genreNames": [
+            "Alternative",
+            "Music"
+          ],
+          "trackCount": 16,
+          "isMasteredForItunes": true,
+          "releaseDate": "2021-07-30",
+          "name": "Happier Than Ever",
+          "recordLabel": "Darkroom/Interscope Records",
+          "upc": "00602438254743",
+          "copyright": "℗ 2021 Darkroom/Interscope Records",
+          "playParams": {
+            "id": "1564530719",
+            "kind": "album"
+          },
+          "editorialNotes": {
+            "standard": "“It wasn't forced, it wasn't pressured, it wasn't scary,” Billie Eilish tells Apple Music of making <i>Happier Than Ever</i>. “It was nice.” Once again written and recorded entirely with her brother FINNEAS, Eilish’s second LP finds the 19-year-old singer-songwriter in a deeply reflective state, using the first year of the pandemic to process the many ways her life has changed and she’s evolved since so quickly becoming one of the world’s most famous and influential teenagers. “I feel like everything I've created before this, as much as I love it, was kind of a battle with myself,” she says. “I've actually talked to artists that are now going through the rise and what I've said to them is, ‘I know what it's like, but I also don't know what it's like for you.’ Because everybody goes through something completely different.”<br />\nA noticeable departure from the genre-averse, slightly sinister edge of 2019’s <i>WHEN WE ALL FALL ASLEEP, WHERE DO WE GO?</i>, much of the production and arrangements here feel open and airy by comparison, inspired in large part by the placid mid-century pop and jazz of torch singer Julie London. And whether she’s sharing new perspective on age (“Getting Older”), sensuality (“Oxytocin”), or the absurdity of fame (“NDA”), there’s a sense of genuine freedom—if not peace—in Eilish’s singing, her voice able to change shape and size as she sees fit, an instrument under her control and no one else's. “I started to feel like a parody of myself, which is super weird,” she says. “I just tried to listen to myself and figure out what I actually liked versus what I thought I would have liked in the past. I had to really evaluate myself and be like, 'What the hell do I want with myself right now?'”<br />\nIt’s a sign of growth, most striking in the clear skies of “my future” and the emotional clarity of the album’s towering title cut, which starts as a gentle ballad and blossoms, quite naturally and unexpectedly, into a growing wave of distorted guitars and distant screams. Both sound like breakthroughs. “There was no thought of, ‘What's this going to be? What track is this?’” she says of the writing process. “We just started writing and we kept writing. Over time, it just literally created itself. It just happened. It was easy.”",
+            "short": "“It wasn't forced, it wasn't pressured, it wasn't scary—it was nice.”"
+          },
+          "isCompilation": false,
+          "contentRating": "explicit"
+        },
+        "relationships": {
+          "tracks": {
+            "href": "/v1/catalog/us/albums/1564530719/tracks",
+            "data": [
+              {
+                "id": "1564530724",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530724",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/04/e2/60/04e260c9-f530-56cf-9bf3-b163ae054371/mzaf_5315780970243830358.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/getting-older/1564530719?i=1564530724",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 244221,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "Getting Older",
+                  "isrc": "USUM72105922",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530724",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564530936",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530936",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/76/00/15/76001558-8318-8baa-555c-37b2f591e9c7/mzaf_11801203009829344130.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/i-didnt-change-my-number/1564530719?i=1564530936",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 158463,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "I Didn't Change My Number",
+                  "isrc": "USUM72105926",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530936",
+                    "kind": "song"
+                  },
+                  "trackNumber": 2,
+                  "composerName": "Billie Eilish & FINNEAS",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1564530941",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530941",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/65/90/fa/6590fa66-c592-502b-2122-3395f1f3d002/mzaf_5653008341160715810.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/billie-bossa-nova/1564530719?i=1564530941",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 196731,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "Billie Bossa Nova",
+                  "isrc": "USUM72105927",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530941",
+                    "kind": "song"
+                  },
+                  "trackNumber": 3,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564530943",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530943",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/28/4e/b1/284eb12a-bd00-40aa-6d51-a9924a8e4c13/mzaf_3712897583725168386.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/my-future/1564530719?i=1564530943",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 210005,
+                  "releaseDate": "2020-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "my future",
+                  "isrc": "USUM72013019",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530943",
+                    "kind": "song"
+                  },
+                  "trackNumber": 4,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564530949",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530949",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/43/99/e3/4399e3d8-74c4-a9f5-62b7-099664cca38e/mzaf_12225089916921844134.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/oxytocin/1564530719?i=1564530949",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 210233,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "Oxytocin",
+                  "isrc": "USUM72104675",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530949",
+                    "kind": "song"
+                  },
+                  "trackNumber": 5,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564530953",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530953",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/f2/d5/54/f2d5542b-7bb3-7b07-d67c-4cbf5da3d522/mzaf_16859115749010897791.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/goldwing/1564530719?i=1564530953",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 151537,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "GOLDWING",
+                  "isrc": "USUM72105928",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530953",
+                    "kind": "song"
+                  },
+                  "trackNumber": 6,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564530954",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530954",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/00/41/50/00415015-cd4b-97cf-8de3-59e492820f6d/mzaf_5951024147918198475.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/lost-cause/1564530719?i=1564530954",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 212496,
+                  "releaseDate": "2021-06-02",
+                  "isAppleDigitalMaster": true,
+                  "name": "Lost Cause",
+                  "isrc": "USUM72105929",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530954",
+                    "kind": "song"
+                  },
+                  "trackNumber": 7,
+                  "composerName": "Billie Eilish & FINNEAS",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1564530955",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530955",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/52/3a/c5/523ac5af-ac88-ca61-4836-ec0414d056d0/mzaf_16242563239765458479.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/halleys-comet/1564530719?i=1564530955",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 234761,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "Halley's Comet",
+                  "isrc": "USUM72105930",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530955",
+                    "kind": "song"
+                  },
+                  "trackNumber": 8,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564530956",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530956",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/80/48/e0/8048e0b4-ea09-dc71-a4f4-929e93b302ce/mzaf_7867151888171163111.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/not-my-responsibility/1564530719?i=1564530956",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 227680,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "Not My Responsibility",
+                  "isrc": "USUM72105931",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530956",
+                    "kind": "song"
+                  },
+                  "trackNumber": 9,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564530959",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530959",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/10/8e/11/108e117f-5993-f5fe-2487-ef452d61fb57/mzaf_12601475935400968927.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/overheated/1564530719?i=1564530959",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 214059,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "OverHeated",
+                  "isrc": "USUM72105932",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530959",
+                    "kind": "song"
+                  },
+                  "trackNumber": 10,
+                  "composerName": "Billie Eilish & FINNEAS",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1564530960",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564530960",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/e2/14/fd/e214fdbd-e90a-d494-8d46-00544ae229a7/mzaf_123186550610641606.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/everybody-dies/1564530719?i=1564530960",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 206623,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "Everybody Dies",
+                  "isrc": "USUM72105933",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564530960",
+                    "kind": "song"
+                  },
+                  "trackNumber": 11,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564531176",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564531176",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/08/a9/c8/08a9c870-211f-4b23-1621-08d64fbb5ba5/mzaf_11543444132301153890.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/your-power/1564530719?i=1564531176",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 245897,
+                  "releaseDate": "2021-04-29",
+                  "isAppleDigitalMaster": true,
+                  "name": "Your Power",
+                  "isrc": "USUM72105934",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564531176",
+                    "kind": "song"
+                  },
+                  "trackNumber": 12,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564531177",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564531177",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/77/a8/a7/77a8a728-dffc-e1e9-df26-970a9857ac91/mzaf_12628913301493234185.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/nda/1564530719?i=1564531177",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 195777,
+                  "releaseDate": "2021-06-09",
+                  "isAppleDigitalMaster": true,
+                  "name": "NDA",
+                  "isrc": "USUM72105935",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564531177",
+                    "kind": "song"
+                  },
+                  "trackNumber": 13,
+                  "composerName": "Billie Eilish & FINNEAS",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1564531181",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564531181",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/0c/5f/10/0c5f101c-8c61-3a40-6f53-0c16fd3d13ae/mzaf_3716904370840330224.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/therefore-i-am/1564530719?i=1564531181",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 173539,
+                  "releaseDate": "2020-11-12",
+                  "isAppleDigitalMaster": true,
+                  "name": "Therefore I Am",
+                  "isrc": "USUM72021500",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564531181",
+                    "kind": "song"
+                  },
+                  "trackNumber": 14,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              },
+              {
+                "id": "1564531202",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564531202",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/d6/6f/58/d66f58c4-50ad-4978-971c-b19c022a440b/mzaf_3392528453380582564.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/happier-than-ever/1564530719?i=1564531202",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 298899,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "Happier Than Ever",
+                  "isrc": "USUM72105936",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564531202",
+                    "kind": "song"
+                  },
+                  "trackNumber": 15,
+                  "composerName": "Billie Eilish & FINNEAS",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1564531204",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1564531204",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/d4/74/32/d4743220-71aa-0c3c-2cc3-0a1e7ad5f6b6/mzaf_7879646835645832144.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/2d/f3/c9/2df3c9fd-e0eb-257c-c035-b04f05a66580/21UMGIM36691.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "6d4d3a",
+                    "textColor1": "fcfbf9",
+                    "textColor2": "ead3b5",
+                    "textColor3": "e0d8d3",
+                    "textColor4": "d1b89c"
+                  },
+                  "artistName": "Billie Eilish",
+                  "url": "https://music.apple.com/us/album/male-fantasy/1564530719?i=1564531204",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 194887,
+                  "releaseDate": "2021-07-30",
+                  "isAppleDigitalMaster": true,
+                  "name": "Male Fantasy",
+                  "isrc": "USUM72105937",
+                  "hasLyrics": true,
+                  "albumName": "Happier Than Ever",
+                  "playParams": {
+                    "id": "1564531204",
+                    "kind": "song"
+                  },
+                  "trackNumber": 16,
+                  "composerName": "Billie Eilish & FINNEAS"
+                }
+              }
+            ]
+          },
+          "artists": {
+            "href": "/v1/catalog/us/albums/1564530719/artists",
+            "data": [
+              {
+                "id": "1065981054",
+                "type": "artists",
+                "href": "/v1/catalog/us/artists/1065981054"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "1568819304",
+        "type": "albums",
+        "href": "/v1/catalog/us/albums/1568819304",
+        "attributes": {
+          "artwork": {
+            "width": 3000,
+            "height": 3000,
+            "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+            "bgColor": "f4eddd",
+            "textColor1": "0a0602",
+            "textColor2": "1e373f",
+            "textColor3": "39342e",
+            "textColor4": "495c5e"
+          },
+          "artistName": "John Mayer",
+          "isSingle": false,
+          "url": "https://music.apple.com/us/album/sob-rock/1568819304",
+          "isComplete": true,
+          "genreNames": [
+            "Pop",
+            "Music"
+          ],
+          "trackCount": 10,
+          "isMasteredForItunes": false,
+          "releaseDate": "2021-07-16",
+          "name": "Sob Rock",
+          "recordLabel": "Columbia",
+          "upc": "886449323081",
+          "copyright": "℗ 2021 Columbia Records, a Division of Sony Music Entertainment",
+          "playParams": {
+            "id": "1568819304",
+            "kind": "album"
+          },
+          "editorialNotes": {
+            "standard": "Once John Mayer mapped out the concept and the songs for <i>Sob Rock</i>, his first studio album since 2017’s <i>The Search for Everything</i>, he promised himself he was going to stick by it. “This is the record where I had 10 songs locked,” John Mayer tells Apple Music. “My record before suffered because the door was open to it the whole time—new songs would come in, old songs would go out. And so it became ‘This is my script, this is my movie.’ We're not going to write a different scene from a different movie.” For the veteran singer-songwriter, that meant immersing himself in the sound of the ’80s—aiming to synthesize a piece of work that feels true to the era while injecting his own flair.<br />\nMayer cozies up to mellow, easygoing blue-eyed soul that oozes with nostalgia at every turn—from his serious, Don Henley-like posture on the album cover to bringing in session musician par excellence Greg Phillinganes (known for his work with Michael Jackson, Stevie Wonder, and Toto) to play keys. As always, his songs serve up a meticulously tidy mix of smooth pop with bluesy accents—though this time around, he does so in a more subdued manner.<br />\nRomantic ballads like “Shouldn’t Matter but It Does” and “Why You No Love Me” ease in with snare drum taps and weeping guitars, as Mayer tries to mend his broken heart. He lets a little looser on “Last Train Home,” stamping in vintage sonic pleasantries like gated drums and slow synth swells as he wonders if his time to settle down in a long-term relationship is running out. It’s a thought that Mayer’s been circling back to more now that he’s in his forties, especially on “Why You No Love Me,” on which he reconsiders how to ask this no-win question. “I have spoken those words for a long time in relationships,” Mayer says. “Maybe it takes 43 years to ask that question, but you still ask it in the language of a child? I've never written more brutal lyrics in my life.”<br />\nEven if Mayer embraces these sounds with his usually slick, demure manner, he was keen on making sure that the album wasn’t too sentimental or overly dramatic. “This is the whole <i>Sob Rock</i> game—get sweet, but never sappy,” he says. “It’s demonstratively sweet and luscious, and melodic and colorful, but it's never to the point where it gets cloying and syrupy. I like to teeter on that line.”",
+            "short": "“This is the whole Sob Rock game—get sweet, but never sappy.”"
+          },
+          "isCompilation": false,
+          "contentRating": "explicit"
+        },
+        "relationships": {
+          "tracks": {
+            "href": "/v1/catalog/us/albums/1568819304/tracks",
+            "data": [
+              {
+                "id": "1568819307",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819307",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/52/0b/91/520b9116-3ca2-e3d6-d927-7766496994c9/mzaf_12645329141995995098.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/last-train-home/1568819304?i=1568819307",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 187310,
+                  "releaseDate": "2021-06-04",
+                  "isAppleDigitalMaster": false,
+                  "name": "Last Train Home",
+                  "isrc": "USSM12101687",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819307",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "John Mayer"
+                }
+              },
+              {
+                "id": "1568819308",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819308",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/18/e6/5e/18e65ebe-6eef-eb01-d80c-17c8afae3ace/mzaf_17026989072630048507.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/shouldnt-matter-but-it-does/1568819304?i=1568819308",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 236735,
+                  "releaseDate": "2021-07-16",
+                  "isAppleDigitalMaster": false,
+                  "name": "Shouldn't Matter but It Does",
+                  "isrc": "USSM12101679",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819308",
+                    "kind": "song"
+                  },
+                  "trackNumber": 2,
+                  "editorialNotes": {
+                    "standard": "The pop-rocker muses on past regrets with heart-aching vocals.",
+                    "short": "The pop-rocker muses on past regrets with heart-aching vocals."
+                  },
+                  "composerName": "John Mayer",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1568819309",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819309",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/7b/f9/f7/7bf9f7af-6caa-c30e-7573-bf02e56ff234/mzaf_12637723486077255015.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/new-light/1568819304?i=1568819309",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 217430,
+                  "releaseDate": "2018-05-10",
+                  "isAppleDigitalMaster": false,
+                  "name": "New Light",
+                  "isrc": "USSM11806100",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819309",
+                    "kind": "song"
+                  },
+                  "trackNumber": 3,
+                  "composerName": "John Mayer & Ernest Wilson"
+                }
+              },
+              {
+                "id": "1568819310",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819310",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/fb/f8/a1/fbf8a1ed-6896-aa28-1358-9768c22f8862/mzaf_11598510675360068820.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/why-you-no-love-me/1568819304?i=1568819310",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 255207,
+                  "releaseDate": "2021-07-16",
+                  "isAppleDigitalMaster": false,
+                  "name": "Why You No Love Me",
+                  "isrc": "USSM12101680",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819310",
+                    "kind": "song"
+                  },
+                  "trackNumber": 4,
+                  "composerName": "John Mayer"
+                }
+              },
+              {
+                "id": "1568819312",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819312",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/fe/09/12/fe091214-690d-d213-c6ff-c99f4e1be036/mzaf_3700030405918971218.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/wild-blue/1568819304?i=1568819312",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 252414,
+                  "releaseDate": "2021-07-16",
+                  "isAppleDigitalMaster": false,
+                  "name": "Wild Blue",
+                  "isrc": "USSM12101681",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819312",
+                    "kind": "song"
+                  },
+                  "trackNumber": 5,
+                  "composerName": "John Mayer"
+                }
+              },
+              {
+                "id": "1568819313",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819313",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/03/7c/d0/037cd0f3-98f9-f11f-aad2-af01b4802a4e/mzaf_13881572990810826269.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/shot-in-the-dark/1568819304?i=1568819313",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 249087,
+                  "releaseDate": "2021-07-16",
+                  "isAppleDigitalMaster": false,
+                  "name": "Shot in the Dark",
+                  "isrc": "USSM12101682",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819313",
+                    "kind": "song"
+                  },
+                  "trackNumber": 6,
+                  "composerName": "John Mayer"
+                }
+              },
+              {
+                "id": "1568819314",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819314",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/21/e9/4a/21e94a2b-873b-f55b-fcfe-a49167ce7af9/mzaf_12721798220460798435.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/i-guess-i-just-feel-like/1568819304?i=1568819314",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 286387,
+                  "releaseDate": "2019-02-22",
+                  "isAppleDigitalMaster": false,
+                  "name": "I Guess I Just Feel Like",
+                  "isrc": "USSM11900959",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819314",
+                    "kind": "song"
+                  },
+                  "trackNumber": 7,
+                  "composerName": "John Mayer"
+                }
+              },
+              {
+                "id": "1568819887",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819887",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/1c/fb/0f/1cfb0f89-db44-27e0-18a9-406893d25511/mzaf_4076652072917533348.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/til-the-right-one-comes/1568819304?i=1568819887",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 219226,
+                  "releaseDate": "2021-07-16",
+                  "isAppleDigitalMaster": false,
+                  "name": "Til the Right One Comes",
+                  "isrc": "USSM12101683",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819887",
+                    "kind": "song"
+                  },
+                  "trackNumber": 8,
+                  "composerName": "John Mayer"
+                }
+              },
+              {
+                "id": "1568819888",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819888",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/1a/84/43/1a844324-fc6e-3dac-a19c-8a3802dee840/mzaf_15012741357605808737.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/carry-me-away/1568819304?i=1568819888",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 159134,
+                  "releaseDate": "2019-09-06",
+                  "isAppleDigitalMaster": false,
+                  "name": "Carry Me Away",
+                  "isrc": "USSM11905957",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819888",
+                    "kind": "song"
+                  },
+                  "trackNumber": 9,
+                  "composerName": "John Mayer"
+                }
+              },
+              {
+                "id": "1568819889",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1568819889",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/0c/39/36/0c39366d-9f27-532b-7c6c-13c9da858fe5/mzaf_11873112140720507932.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/b0/81/99/b081991e-22da-957d-226d-688dc35f7843/886449323081.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f4eddd",
+                    "textColor1": "0a0602",
+                    "textColor2": "1e373f",
+                    "textColor3": "39342e",
+                    "textColor4": "495c5e"
+                  },
+                  "artistName": "John Mayer",
+                  "url": "https://music.apple.com/us/album/all-i-want-is-to-be-with-you/1568819304?i=1568819889",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 244140,
+                  "releaseDate": "2021-07-16",
+                  "isAppleDigitalMaster": false,
+                  "name": "All I Want Is to Be With You",
+                  "isrc": "USSM12101684",
+                  "hasLyrics": true,
+                  "albumName": "Sob Rock",
+                  "playParams": {
+                    "id": "1568819889",
+                    "kind": "song"
+                  },
+                  "trackNumber": 10,
+                  "composerName": "John Mayer"
+                }
+              }
+            ]
+          },
+          "artists": {
+            "href": "/v1/catalog/us/albums/1568819304/artists",
+            "data": [
+              {
+                "id": "472054",
+                "type": "artists",
+                "href": "/v1/catalog/us/artists/472054"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }

--- a/Tests/AmuseKitTests/DataModels/Catalog/catalog_artists.json
+++ b/Tests/AmuseKitTests/DataModels/Catalog/catalog_artists.json
@@ -1,0 +1,314 @@
+{
+    "data": [
+      {
+        "id": "1065981054",
+        "type": "artists",
+        "href": "/v1/catalog/us/artists/1065981054",
+        "attributes": {
+          "url": "https://music.apple.com/us/artist/billie-eilish/1065981054",
+          "artwork": {
+            "width": 1347,
+            "height": 1347,
+            "url": "https://is1-ssl.mzstatic.com/image/thumb/Features125/v4/aa/64/c1/aa64c19b-b273-76ee-f785-05ee22555de4/pr_source.png/{w}x{h}bb.jpg",
+            "bgColor": "675540",
+            "textColor1": "f8ebeb",
+            "textColor2": "e3d5c5",
+            "textColor3": "dbcdc9",
+            "textColor4": "cabbaa"
+          },
+          "name": "Billie Eilish",
+          "genreNames": [
+            "Alternative"
+          ]
+        },
+        "relationships": {
+          "albums": {
+            "href": "/v1/catalog/us/artists/1065981054/albums",
+            "next": "/v1/catalog/us/artists/1065981054/albums?offset=25",
+            "data": [
+              {
+                "id": "1450695723",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1450695723"
+              },
+              {
+                "id": "1440898929",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1440898929"
+              },
+              {
+                "id": "1564530719",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1564530719"
+              },
+              {
+                "id": "1440894250",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1440894250"
+              },
+              {
+                "id": "1564530526",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1564530526"
+              },
+              {
+                "id": "1369379667",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1369379667"
+              },
+              {
+                "id": "1487502456",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1487502456"
+              },
+              {
+                "id": "1498647640",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1498647640"
+              },
+              {
+                "id": "1362273458",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1362273458"
+              },
+              {
+                "id": "1539499185",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1539499185"
+              },
+              {
+                "id": "1525322225",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1525322225"
+              },
+              {
+                "id": "1445297971",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1445297971"
+              },
+              {
+                "id": "1442107599",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1442107599"
+              },
+              {
+                "id": "1472563379",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1472563379"
+              },
+              {
+                "id": "1448440122",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1448440122"
+              },
+              {
+                "id": "1584261635",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1584261635"
+              },
+              {
+                "id": "1354027915",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1354027915"
+              },
+              {
+                "id": "1492126606",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1492126606"
+              },
+              {
+                "id": "1554563080",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1554563080"
+              },
+              {
+                "id": "1584262454",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1584262454"
+              },
+              {
+                "id": "1444889914",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1444889914"
+              },
+              {
+                "id": "1444861647",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1444861647"
+              },
+              {
+                "id": "1549917101",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1549917101"
+              },
+              {
+                "id": "1444885102",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1444885102"
+              },
+              {
+                "id": "1444890649",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1444890649"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "1264549322",
+        "type": "artists",
+        "href": "/v1/catalog/us/artists/1264549322",
+        "attributes": {
+          "url": "https://music.apple.com/us/artist/maisie-peters/1264549322",
+          "artwork": {
+            "width": 2000,
+            "height": 2000,
+            "url": "https://is1-ssl.mzstatic.com/image/thumb/Features125/v4/ae/ac/ff/aeacff80-5a3f-0116-066a-b0d7f612a0ad/pr_source.png/{w}x{h}bb.jpg",
+            "bgColor": "bdb4b7",
+            "textColor1": "120b10",
+            "textColor2": "2c1b13",
+            "textColor3": "342d31",
+            "textColor4": "493934"
+          },
+          "name": "Maisie Peters",
+          "genreNames": [
+            "Pop"
+          ]
+        },
+        "relationships": {
+          "albums": {
+            "href": "/v1/catalog/us/artists/1264549322/albums",
+            "next": "/v1/catalog/us/artists/1264549322/albums?offset=25",
+            "data": [
+              {
+                "id": "1571697083",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1571697083"
+              },
+              {
+                "id": "1437544342",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1437544342"
+              },
+              {
+                "id": "1480402168",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1480402168"
+              },
+              {
+                "id": "1565171378",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1565171378"
+              },
+              {
+                "id": "1378602794",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1378602794"
+              },
+              {
+                "id": "1458393267",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1458393267"
+              },
+              {
+                "id": "1531152200",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1531152200"
+              },
+              {
+                "id": "1264549314",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1264549314"
+              },
+              {
+                "id": "1509493751",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1509493751"
+              },
+              {
+                "id": "1451620674",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1451620674"
+              },
+              {
+                "id": "1502640847",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1502640847"
+              },
+              {
+                "id": "1408860682",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1408860682"
+              },
+              {
+                "id": "1297956063",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1297956063"
+              },
+              {
+                "id": "1517873276",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1517873276"
+              },
+              {
+                "id": "1494138304",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1494138304"
+              },
+              {
+                "id": "1571538034",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1571538034"
+              },
+              {
+                "id": "1536777591",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1536777591"
+              },
+              {
+                "id": "1455498277",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1455498277"
+              },
+              {
+                "id": "1578002158",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1578002158"
+              },
+              {
+                "id": "1601019905",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1601019905"
+              },
+              {
+                "id": "1523067872",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1523067872"
+              },
+              {
+                "id": "1483802099",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1483802099"
+              },
+              {
+                "id": "1575571442",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1575571442"
+              },
+              {
+                "id": "1489344026",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1489344026"
+              },
+              {
+                "id": "1539009003",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1539009003"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }

--- a/Tests/AmuseKitTests/DataModels/Catalog/catalog_music-videos.json
+++ b/Tests/AmuseKitTests/DataModels/Catalog/catalog_music-videos.json
@@ -1,0 +1,132 @@
+{
+    "data": [
+        {
+            "id": "1553279848",
+            "type": "music-videos",
+            "href": "/v1/catalog/us/music-videos/1553279848",
+            "attributes": {
+                "previews": [
+                    {
+                        "url": "https://video-ssl.itunes.apple.com/itunes-assets/Video114/v4/c8/14/3c/c8143cb4-e58a-8075-44b0-602f43d7646f/mzvf_2953199973497507158.720w.h264lc.U.p.m4v",
+                        "hlsUrl": "https://play.itunes.apple.com/WebObjects/MZPlay.woa/hls/playlist.m3u8?cc=US&a=1553279848&id=231169237&l=en&aec=HD",
+                        "artwork": {
+                            "width": 1560,
+                            "height": 1080,
+                            "url": "https://is3-ssl.mzstatic.com/image/thumb/Video124/v4/26/6b/fe/266bfe0f-9d0c-e992-ae86-ce97cb251e40/Job80599ed4-a39e-455a-9f99-5bdc54c44284-109334076-PreviewImage_preview_image_43000_video_sdr-Time1613053183818.png/{w}x{h}bb.jpeg",
+                            "bgColor": "cadee0",
+                            "textColor1": "101414",
+                            "textColor2": "181e1f",
+                            "textColor3": "353c3d",
+                            "textColor4": "3b4445"
+                        }
+                    }
+                ],
+                "artwork": {
+                    "width": 640,
+                    "height": 360,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Video124/v4/3f/1e/6f/3f1e6f35-6960-3f0e-0a0c-8701aa2012d4/dj.bcvxpufw.jpg/{w}x{h}mv.jpeg",
+                    "bgColor": "000000",
+                    "textColor1": "86bff9",
+                    "textColor2": "7cb0ea",
+                    "textColor3": "6b98c7",
+                    "textColor4": "638dbb"
+                },
+                "artistName": "Dua Lipa",
+                "url": "https://music.apple.com/us/music-video/were-good/1553279848",
+                "genreNames": [
+                    "Pop"
+                ],
+                "has4K": false,
+                "durationInMillis": 191913,
+                "releaseDate": "2021-02-12",
+                "name": "We’re Good",
+                "isrc": "GB1302001140",
+                "playParams": {
+                    "id": "1553279848",
+                    "kind": "musicVideo"
+                },
+                "hasHDR": false
+            },
+            "relationships": {
+                "albums": {
+                    "href": "/v1/catalog/us/music-videos/1553279848/albums",
+                    "data": []
+                },
+                "artists": {
+                    "href": "/v1/catalog/us/music-videos/1553279848/artists",
+                    "data": [
+                        {
+                            "id": "1031397873",
+                            "type": "artists",
+                            "href": "/v1/catalog/us/artists/1031397873"
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "id": "1549013065",
+            "type": "music-videos",
+            "href": "/v1/catalog/us/music-videos/1549013065",
+            "attributes": {
+                "previews": [
+                    {
+                        "url": "https://video-ssl.itunes.apple.com/itunes-assets/Video124/v4/e0/5f/88/e05f8810-e2c5-8b06-d9da-d58829fe590b/mzvf_12665898235115114036.720w.h264lc.U.p.m4v",
+                        "hlsUrl": "https://play.itunes.apple.com/WebObjects/MZPlay.woa/hls/playlist.m3u8?cc=US&a=1549013065&id=224630612&l=en&aec=HD",
+                        "artwork": {
+                            "width": 1912,
+                            "height": 1072,
+                            "url": "https://is5-ssl.mzstatic.com/image/thumb/Video124/v4/ae/b6/41/aeb64141-a00e-d4b4-e19e-7fd00eff0534/Jobc9e8f50e-a109-4976-9f16-ee7871899a6c-108689753-PreviewImage_preview_image_45000_video_sdr-Time1610655522053.png/{w}x{h}bb.jpeg",
+                            "bgColor": "0c040c",
+                            "textColor1": "eb707e",
+                            "textColor2": "e75b6b",
+                            "textColor3": "be5a67",
+                            "textColor4": "bb4a58"
+                        }
+                    }
+                ],
+                "artwork": {
+                    "width": 1912,
+                    "height": 1072,
+                    "url": "https://is4-ssl.mzstatic.com/image/thumb/Video124/v4/1a/54/02/1a5402a4-48bb-dee3-c0c4-368bfee4158d/21UMGIM01401.crop.jpg/{w}x{h}mv.jpeg",
+                    "bgColor": "38332d",
+                    "textColor1": "e8d9d2",
+                    "textColor2": "d9ccce",
+                    "textColor3": "c4b8b1",
+                    "textColor4": "b9aeae"
+                },
+                "artistName": "Selena Gomez",
+                "url": "https://music.apple.com/us/music-video/de-una-vez/1549013065",
+                "genreNames": [
+                    "Latin"
+                ],
+                "has4K": false,
+                "durationInMillis": 168467,
+                "releaseDate": "2021-01-14",
+                "name": "De Una Vez",
+                "isrc": "USUMV2100129",
+                "playParams": {
+                    "id": "1549013065",
+                    "kind": "musicVideo"
+                },
+                "hasHDR": false
+            },
+            "relationships": {
+                "albums": {
+                    "href": "/v1/catalog/us/music-videos/1549013065/albums",
+                    "data": []
+                },
+                "artists": {
+                    "href": "/v1/catalog/us/music-videos/1549013065/artists",
+                    "data": [
+                        {
+                            "id": "280215834",
+                            "type": "artists",
+                            "href": "/v1/catalog/us/artists/280215834"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/Tests/AmuseKitTests/DataModels/Catalog/catalog_playlists.json
+++ b/Tests/AmuseKitTests/DataModels/Catalog/catalog_playlists.json
@@ -1,0 +1,2059 @@
+{
+    "data": [
+      {
+        "id": "pl.f4d106fed2bd41149aaacabb233eb5eb",
+        "type": "playlists",
+        "href": "/v1/catalog/us/playlists/pl.f4d106fed2bd41149aaacabb233eb5eb",
+        "attributes": {
+          "artwork": {
+            "width": 1080,
+            "height": 1080,
+            "url": "https://is1-ssl.mzstatic.com/image/thumb/Features122/v4/cf/a6/0b/cfa60b1a-2801-d01f-43ca-32cf75b3bd52/7d2ff641-e31b-48ae-9ba8-1d95435405cf.png/{w}x{h}SC.DN01.jpg?l=en-US",
+            "bgColor": "f4f4f4",
+            "textColor1": "000000",
+            "textColor2": "232121",
+            "textColor3": "473e3b",
+            "textColor4": "444243"
+          },
+          "isChart": false,
+          "url": "https://music.apple.com/us/playlist/todays-hits/pl.f4d106fed2bd41149aaacabb233eb5eb",
+          "lastModifiedDate": "2022-04-13T19:01:51Z",
+          "name": "Today’s Hits",
+          "playlistType": "editorial",
+          "curatorName": "Apple Music Hits",
+          "playParams": {
+            "id": "pl.f4d106fed2bd41149aaacabb233eb5eb",
+            "kind": "playlist",
+            "versionHash": "993793b38a53ec95717db443e32a4f9f984ee4c7b8ca88494fa33f126a8ca317"
+          },
+          "description": {
+            "standard": "The first taste of Harry Styles’ forthcoming third album, <I>Harry’s House</I>, has arrived. On “As It Was,” a brisk, daydreamy ballad co-written with Kid Harpoon and Tyler Johnson, the boy-band icon turned bona fide rock star laments one of life’s painful dichotomies: the temptation to look back while being forced to move on ahead. “You know it’s not the same as it was,” he sings on the hook. “In this world, it’s just us.” Add Today’s Hits to your library to stay up on the biggest songs in pop, hip-hop, R&B, and more.",
+            "short": "“As It Was,” the daydreamy first single from Harry’s new album, has arrived—in Spatial."
+          }
+        },
+        "relationships": {
+          "tracks": {
+            "href": "/v1/catalog/us/playlists/pl.f4d106fed2bd41149aaacabb233eb5eb/tracks",
+            "data": [
+              {
+                "id": "1615585008",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1615585008",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview112/v4/ed/6b/40/ed6b4050-43a0-7f4d-759a-1575c1ab5022/mzaf_4656295327266779662.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/2a/19/fb/2a19fb85-2f70-9e44-f2a9-82abe679b88e/886449990061.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "d2c8ad",
+                    "textColor1": "090f12",
+                    "textColor2": "3d2b16",
+                    "textColor3": "313431",
+                    "textColor4": "5b4a34"
+                  },
+                  "artistName": "Harry Styles",
+                  "url": "https://music.apple.com/us/album/as-it-was/1615584999?i=1615585008",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 167303,
+                  "releaseDate": "2022-03-31",
+                  "isAppleDigitalMaster": false,
+                  "name": "As It Was",
+                  "isrc": "USSM12200612",
+                  "hasLyrics": true,
+                  "albumName": "Harry's House",
+                  "playParams": {
+                    "id": "1615585008",
+                    "kind": "song"
+                  },
+                  "trackNumber": 4,
+                  "composerName": "Harry Styles, Kid Harpoon & Tyler Johnson"
+                }
+              },
+              {
+                "id": "1556175854",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1556175854",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/f1/c6/4d/f1c64de7-f813-6d3a-abf3-d980882070ab/mzaf_12341366234979933796.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music124/v4/f5/7a/9e/f57a9e6a-31c8-0784-dfbd-4a0120bfd4af/21UMGIM17517.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "1b190d",
+                    "textColor1": "97e8d9",
+                    "textColor2": "7be9cf",
+                    "textColor3": "7ebfb0",
+                    "textColor4": "68c0a8"
+                  },
+                  "artistName": "Justin Bieber",
+                  "url": "https://music.apple.com/us/album/ghost/1556175419?i=1556175854",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 153190,
+                  "releaseDate": "2021-03-19",
+                  "isAppleDigitalMaster": true,
+                  "name": "Ghost",
+                  "isrc": "USUM72102635",
+                  "hasLyrics": true,
+                  "albumName": "Justice",
+                  "playParams": {
+                    "id": "1556175854",
+                    "kind": "song"
+                  },
+                  "trackNumber": 11,
+                  "composerName": "Justin Bieber, Jonathan Bellion, Jordan K. Johnson, Stefan Johnson & Michael Pollack"
+                }
+              },
+              {
+                "id": "1606052735",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1606052735",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/75/63/15/756315e7-1b13-81d3-e6ae-d9c8f216b5c6/mzaf_3834926278750257073.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/40/53/7e/40537e1e-263e-a069-a2c0-63c332180343/886449820757.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f6cac9",
+                    "textColor1": "060f0b",
+                    "textColor2": "41311d",
+                    "textColor3": "363431",
+                    "textColor4": "654f3f"
+                  },
+                  "artistName": "Tate McRae",
+                  "url": "https://music.apple.com/us/album/shes-all-i-wanna-be/1606052727?i=1606052735",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 206772,
+                  "releaseDate": "2022-02-04",
+                  "isAppleDigitalMaster": false,
+                  "name": "she's all i wanna be",
+                  "isrc": "USRC12103120",
+                  "hasLyrics": true,
+                  "albumName": "she's all i wanna be - Single",
+                  "playParams": {
+                    "id": "1606052735",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Tate McRae & Greg Kurstin"
+                }
+              },
+              {
+                "id": "1578986673",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1578986673",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/10/9c/1e/109c1e12-6693-4c71-6d2e-44b2026a0710/mzaf_13345609525827382020.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/ec/2f/92/ec2f929f-e7ea-b291-42d7-75081bd808a1/21UMGIM68484.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "ffffff",
+                    "textColor1": "000000",
+                    "textColor2": "1e1f1c",
+                    "textColor3": "333333",
+                    "textColor4": "4b4b4a"
+                  },
+                  "artistName": "Elton John & Dua Lipa",
+                  "url": "https://music.apple.com/us/album/cold-heart-pnau-remix/1578986656?i=1578986673",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 202735,
+                  "releaseDate": "2021-08-13",
+                  "isAppleDigitalMaster": true,
+                  "name": "Cold Heart (PNAU Remix)",
+                  "isrc": "GBUM72104705",
+                  "hasLyrics": true,
+                  "albumName": "Cold Heart (PNAU Remix) - Single",
+                  "playParams": {
+                    "id": "1578986673",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Elton John, Bernie Taupin, Peter Mayes, Nicholas Littlemore & Sam Littlemore"
+                }
+              },
+              {
+                "id": "1593185593",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1593185593",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview122/v4/5e/27/6c/5e276c72-8912-96c8-e172-cedcba40d6dd/mzaf_7238388583545842546.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/c5/ba/2b/c5ba2b96-ff06-5f58-35ad-1c070973cee7/190296362989.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "5e38cc",
+                    "textColor1": "f1e2ff",
+                    "textColor2": "efcdff",
+                    "textColor3": "d3c0f4",
+                    "textColor4": "d1aff4"
+                  },
+                  "artistName": "Anitta",
+                  "url": "https://music.apple.com/us/album/envolver/1593185587?i=1593185593",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop Latino",
+                    "Music",
+                    "Latin"
+                  ],
+                  "durationInMillis": 193806,
+                  "releaseDate": "2021-11-11",
+                  "isAppleDigitalMaster": true,
+                  "name": "Envolver",
+                  "isrc": "USWL12100576",
+                  "hasLyrics": true,
+                  "albumName": "Envolver - Single",
+                  "playParams": {
+                    "id": "1593185593",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Cristian Andrés Salazar, Freddy Montalvo, José Carlos Cruz, Julio Manuel González & Larissa de Macedo Machado"
+                }
+              },
+              {
+                "id": "1618136917",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1618136917",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview112/v4/9d/09/be/9d09be7a-49ee-1f3c-99fc-af9d9cfb5e9c/mzaf_18446638603385210363.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 1425,
+                    "height": 1425,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/e6/b8/83/e6b88344-8d5d-d353-06bc-3204d87071e6/075679759252.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "e5dad8",
+                    "textColor1": "0b0c08",
+                    "textColor2": "221c16",
+                    "textColor3": "363532",
+                    "textColor4": "49423d"
+                  },
+                  "artistName": "Jack Harlow",
+                  "url": "https://music.apple.com/us/album/first-class/1618136433?i=1618136917",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 173948,
+                  "releaseDate": "2022-04-08",
+                  "isAppleDigitalMaster": false,
+                  "name": "First Class",
+                  "isrc": "USAT22203024",
+                  "hasLyrics": true,
+                  "albumName": "Come Home The Kids Miss You",
+                  "playParams": {
+                    "id": "1618136917",
+                    "kind": "song"
+                  },
+                  "trackNumber": 4,
+                  "composerName": "Christopher Bridges, Douglas Ford, Elvis Williams, Jack Harlow, Jamal Jones, Jasper Lee Harris, Jose Velazquez, Micaiah Raheem, Nickie Jon Pabón, Roget Chahayed, Ryan Vojtesak, Stacy Ferguson & Will Adams",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1590438674",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1590438674",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/b0/35/ac/b035aca7-eaa0-0206-508a-1e3899ba433f/mzaf_14400031600884061270.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 1425,
+                    "height": 1425,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/d4/46/bc/d446bcf7-e633-ab67-a2fe-35a95ca74a6c/075679766038.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "000000",
+                    "textColor1": "efd26f",
+                    "textColor2": "cd9f2f",
+                    "textColor3": "bfa859",
+                    "textColor4": "a47f26"
+                  },
+                  "artistName": "Tiësto & Ava Max",
+                  "url": "https://music.apple.com/us/album/the-motto/1590438335?i=1590438674",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Dance",
+                    "Music",
+                    "Pop"
+                  ],
+                  "durationInMillis": 164819,
+                  "releaseDate": "2021-11-04",
+                  "isAppleDigitalMaster": false,
+                  "name": "The Motto",
+                  "isrc": "CYA112001070",
+                  "hasLyrics": true,
+                  "albumName": "The Motto - Single",
+                  "playParams": {
+                    "id": "1590438674",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Amanda Ava Koci, Claudia Valentina, Pablo Bowman, Peter Rycroft, Sarah Blanchard & Tijs Verwest"
+                }
+              },
+              {
+                "id": "1618285316",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1618285316",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview122/v4/4d/41/6c/4d416c8b-aa21-3fd6-3e52-3cfc3a4221df/mzaf_7499053389427491034.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/fc/1e/a5/fc1ea575-13ff-4a85-c158-962042ecdcd8/22UMGIM38834.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "353535",
+                    "textColor1": "ececec",
+                    "textColor2": "dcc6c6",
+                    "textColor3": "c7c7c7",
+                    "textColor4": "bba9a9"
+                  },
+                  "artistName": "Lil Baby",
+                  "url": "https://music.apple.com/us/album/in-a-minute/1618285311?i=1618285316",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 200471,
+                  "releaseDate": "2022-04-08",
+                  "isAppleDigitalMaster": true,
+                  "name": "In A Minute",
+                  "isrc": "USUG12200033",
+                  "hasLyrics": true,
+                  "albumName": "In A Minute - Single",
+                  "playParams": {
+                    "id": "1618285316",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Dominique Jones, Kai Hasegawa, Ethan Hayes, Ellie Goulding, James Eliot & Howard New",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1617656020",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1617656020",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/39/a8/23/39a82321-7688-47d9-9cec-93ee0541faef/mzaf_8527689616448923136.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music122/v4/8b/d7/1e/8bd71ea5-597c-2cfe-6b9a-9d6edd7e03ca/886449849307.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "ffffff",
+                    "textColor1": "0d0b04",
+                    "textColor2": "002e19",
+                    "textColor3": "3e3c36",
+                    "textColor4": "335847"
+                  },
+                  "artistName": "BIA & J. Cole",
+                  "url": "https://music.apple.com/us/album/london/1617656019?i=1617656020",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 250723,
+                  "releaseDate": "2022-04-08",
+                  "isAppleDigitalMaster": false,
+                  "name": "LONDON",
+                  "isrc": "USSM12200193",
+                  "hasLyrics": true,
+                  "albumName": "LONDON - Single",
+                  "playParams": {
+                    "id": "1617656020",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Bianca Landrau, Abdul Aziz Dieng, Jon Glass, Timothy John Nihan & J. Cole",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1616190902",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1616190902",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview112/v4/85/93/16/85931610-cb63-0879-d097-cd322efbd944/mzaf_15979770130176178681.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/4b/4c/2f/4b4c2f27-a28d-1707-24ef-2d9aacf7f439/22UMGIM33759.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "0b0b0b",
+                    "textColor1": "1cf288",
+                    "textColor2": "19de85",
+                    "textColor3": "19c46f",
+                    "textColor4": "16b46d"
+                  },
+                  "artistName": "Nicki Minaj",
+                  "url": "https://music.apple.com/us/album/we-go-up-feat-fivio-foreign/1616190898?i=1616190902",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 255189,
+                  "releaseDate": "2022-03-25",
+                  "isAppleDigitalMaster": true,
+                  "name": "We Go Up (feat. Fivio Foreign)",
+                  "isrc": "USUM72204900",
+                  "hasLyrics": true,
+                  "albumName": "We Go Up (feat. Fivio Foreign) - Single",
+                  "playParams": {
+                    "id": "1616190902",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Onika Maraj, Joshua Goods, Anthony Woart Jr., Maxie Ryles, Szymon Świątczak & Konrad Zasada",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1508562516",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1508562516",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/d6/34/b2/d634b201-0f5f-ad53-53d9-1d234d8cb906/mzaf_4956443266741752293.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/da/8b/77/da8b7731-6f4f-eacf-5e74-8b23389eefa1/20UMGIM03371.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "ccabe7",
+                    "textColor1": "0c000f",
+                    "textColor2": "33003d",
+                    "textColor3": "32223a",
+                    "textColor4": "52225f"
+                  },
+                  "artistName": "Glass Animals",
+                  "url": "https://music.apple.com/us/album/heat-waves/1508562310?i=1508562516",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 238805,
+                  "releaseDate": "2020-06-29",
+                  "isAppleDigitalMaster": true,
+                  "name": "Heat Waves",
+                  "isrc": "GBUM72000433",
+                  "hasLyrics": true,
+                  "albumName": "Dreamland",
+                  "playParams": {
+                    "id": "1508562516",
+                    "kind": "song"
+                  },
+                  "trackNumber": 14,
+                  "composerName": "Dave Bayley"
+                }
+              },
+              {
+                "id": "1608118905",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1608118905",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/3d/c4/bc/3dc4bc45-3a17-2fbc-63b2-c34490a8144f/mzaf_15282976483271231195.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/d9/48/6f/d9486f75-e228-26c2-9498-befd009e2a90/22UMGIM11298.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "dee3e6",
+                    "textColor1": "21242d",
+                    "textColor2": "32333b",
+                    "textColor3": "474a52",
+                    "textColor4": "54565d"
+                  },
+                  "artistName": "Machine Gun Kelly & blackbear",
+                  "url": "https://music.apple.com/us/album/make-up-sex/1608118564?i=1608118905",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 122570,
+                  "releaseDate": "2022-03-25",
+                  "isAppleDigitalMaster": true,
+                  "name": "make up sex",
+                  "isrc": "USUM72112363",
+                  "hasLyrics": true,
+                  "albumName": "mainstream sellout",
+                  "playParams": {
+                    "id": "1608118905",
+                    "kind": "song"
+                  },
+                  "trackNumber": 7,
+                  "composerName": "Travis Barker, Omer Fedi, Colson Baker, Nick Long & Matthew Musto",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1571169191",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1571169191",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/3f/1e/20/3f1e2087-98f8-f767-e0c9-3e7a1459a1f3/mzaf_17092363549199162610.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/eb/63/fc/eb63fc4c-f36b-5981-a790-8f05c8dd2df1/886449138852.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "0e0e23",
+                    "textColor1": "ffffff",
+                    "textColor2": "8083f8",
+                    "textColor3": "ceced2",
+                    "textColor4": "696ccd"
+                  },
+                  "artistName": "Doja Cat",
+                  "url": "https://music.apple.com/us/album/get-into-it-yuh/1571168930?i=1571169191",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 138293,
+                  "releaseDate": "2021-06-25",
+                  "isAppleDigitalMaster": true,
+                  "name": "Get Into It (Yuh)",
+                  "isrc": "USRC12101535",
+                  "hasLyrics": true,
+                  "albumName": "Planet Her",
+                  "playParams": {
+                    "id": "1571169191",
+                    "kind": "song"
+                  },
+                  "trackNumber": 4,
+                  "composerName": "Amala Zandile Dlamini, Ari Starace & Sheldon Yu-Ting Cheung",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1610834870",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1610834870",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/8b/80/21/8b8021c3-7084-916e-426d-c93d9116f1f8/mzaf_8859912813450898243.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/b7/e3/2f/b7e32fd7-7ca3-edf6-7df8-861bfcfd6f9a/886449526772.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "5d5747",
+                    "textColor1": "fcf9f2",
+                    "textColor2": "f0d6ba",
+                    "textColor3": "dcd9d0",
+                    "textColor4": "d3bda3"
+                  },
+                  "artistName": "Camila Cabello",
+                  "url": "https://music.apple.com/us/album/psychofreak-feat-willow/1610834866?i=1610834870",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 201495,
+                  "releaseDate": "2022-04-08",
+                  "isAppleDigitalMaster": false,
+                  "name": "psychofreak (feat. WILLOW)",
+                  "isrc": "USSM12201108",
+                  "hasLyrics": true,
+                  "albumName": "Familia",
+                  "playParams": {
+                    "id": "1610834870",
+                    "kind": "song"
+                  },
+                  "trackNumber": 3,
+                  "composerName": "Camila Cabello, Tom Peyton, Willow Smith, Eric Frederic & Scott Harris"
+                }
+              },
+              {
+                "id": "1578326262",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1578326262",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/0c/2e/d9/0c2ed928-bd02-72cd-b44c-9e906a594f8d/mzaf_15516520863399347490.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/9d/69/f1/9d69f15c-7bcc-24e9-0adc-ec3afd0bf5cc/886449473663.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "0f0818",
+                    "textColor1": "d3d2e2",
+                    "textColor2": "c5c7d8",
+                    "textColor3": "aca9ba",
+                    "textColor4": "a0a1b1"
+                  },
+                  "artistName": "The Kid LAROI & Justin Bieber",
+                  "url": "https://music.apple.com/us/album/stay/1578326258?i=1578326262",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 141806,
+                  "releaseDate": "2021-07-09",
+                  "isAppleDigitalMaster": false,
+                  "name": "STAY",
+                  "isrc": "USSM12103949",
+                  "hasLyrics": true,
+                  "albumName": "F*CK LOVE 3+: OVER YOU",
+                  "playParams": {
+                    "id": "1578326262",
+                    "kind": "song"
+                  },
+                  "trackNumber": 3,
+                  "composerName": "Justin Bieber, Charlton Howard, Blake Slatkin, Omer Fedi, Charlie Puth, Magnus Høiberg, Michael Mule, Isaac DeBoni & Subhaan Rahmaan",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1613376653",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1613376653",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview112/v4/60/02/01/600201ae-efd2-dc4a-a525-2ac27ad1db83/mzaf_17279416121200249358.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 2100,
+                    "height": 2100,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/a4/9a/11/a49a118a-546b-3e7f-4112-92058392e282/850039440298.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "150a10",
+                    "textColor1": "f0f0f2",
+                    "textColor2": "e09c7c",
+                    "textColor3": "c4c2c5",
+                    "textColor4": "b87f66"
+                  },
+                  "artistName": "Megan Thee Stallion & Dua Lipa",
+                  "url": "https://music.apple.com/us/album/sweetest-pie/1613376645?i=1613376653",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music",
+                    "Hip-Hop/Rap"
+                  ],
+                  "durationInMillis": 201334,
+                  "releaseDate": "2022-03-11",
+                  "isAppleDigitalMaster": true,
+                  "name": "Sweetest Pie",
+                  "isrc": "QMCE32200232",
+                  "hasLyrics": true,
+                  "albumName": "Sweetest Pie - Single",
+                  "playParams": {
+                    "id": "1613376653",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Clarence Coffee Jr, Dua Lipa, John Walsh Homen, Joshua Isaiah Parker, Megan Pete, Nija Aisha-Alayja Charles, Sarah Hudson & Stephen Kozmeniuk",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1618287720",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1618287720",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview122/v4/20/82/7a/20827a5a-9d1f-cf06-392f-13d65d7985a0/mzaf_6222343294584303248.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 1400,
+                    "height": 1400,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/16/9a/7a/169a7a3f-6f6f-1dba-8d54-7d9a45f14db0/8720355633099_Cover.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "222220",
+                    "textColor1": "dfd7c4",
+                    "textColor2": "d6cbba",
+                    "textColor3": "b9b3a3",
+                    "textColor4": "b2a99b"
+                  },
+                  "artistName": "Yahritza Y Su Esencia",
+                  "url": "https://music.apple.com/us/album/soy-el-%C3%BAnico/1618287709?i=1618287720",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Música Mexicana",
+                    "Music",
+                    "Latin"
+                  ],
+                  "durationInMillis": 214000,
+                  "releaseDate": "2022-03-25",
+                  "isAppleDigitalMaster": false,
+                  "name": "Soy El Único",
+                  "isrc": "USA2P2208434",
+                  "hasLyrics": true,
+                  "albumName": "Obsessed - EP",
+                  "playParams": {
+                    "id": "1618287720",
+                    "kind": "song"
+                  },
+                  "trackNumber": 3,
+                  "composerName": "Yahritza Martinez"
+                }
+              },
+              {
+                "id": "1610328930",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1610328930",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/65/bd/07/65bd077f-b7c5-c8ff-a727-a5fe60e99d85/mzaf_16293019882878690978.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 1500,
+                    "height": 1500,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/37/ad/a3/37ada314-d9b3-a011-cf5a-67795df61322/4050538785609.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "fcfcfe",
+                    "textColor1": "0d0e10",
+                    "textColor2": "393031",
+                    "textColor3": "3c3e3f",
+                    "textColor4": "60595a"
+                  },
+                  "artistName": "5 Seconds of Summer",
+                  "url": "https://music.apple.com/us/album/complete-mess/1610328928?i=1610328930",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 206361,
+                  "releaseDate": "2022-03-02",
+                  "isAppleDigitalMaster": true,
+                  "name": "COMPLETE MESS",
+                  "isrc": "QMRSZ2200096",
+                  "hasLyrics": true,
+                  "albumName": "COMPLETE MESS - Single",
+                  "playParams": {
+                    "id": "1610328930",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Ashton Irwin, Calum Hood, Luke Hemmings & Michael Clifford"
+                }
+              },
+              {
+                "id": "1609137778",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1609137778",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview122/v4/ee/b8/15/eeb8153f-a9b7-043a-5d09-a9dcc71e5a95/mzaf_7072578783170473923.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/9e/9b/e6/9e9be6a5-431d-3f48-f7b8-76d0726b909e/886449885053.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "8696b7",
+                    "textColor1": "0e0e0f",
+                    "textColor2": "0e111b",
+                    "textColor3": "262930",
+                    "textColor4": "262c3a"
+                  },
+                  "artistName": "Becky G. & KAROL G",
+                  "url": "https://music.apple.com/us/album/mamiii/1609137776?i=1609137778",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Latin",
+                    "Music"
+                  ],
+                  "durationInMillis": 226088,
+                  "releaseDate": "2022-02-10",
+                  "isAppleDigitalMaster": false,
+                  "name": "MAMIII",
+                  "isrc": "USRC12200425",
+                  "hasLyrics": true,
+                  "albumName": "MAMIII - Single",
+                  "playParams": {
+                    "id": "1609137778",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Rebbeca Marie Gomez, Daniel Echavarria Oviedo, Elena Rose & Carolina Giraldo Navarro"
+                }
+              },
+              {
+                "id": "1609153365",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1609153365",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/95/bc/8b/95bc8baa-e30c-e473-fc01-23e0f32a701d/mzaf_14860574255381362172.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/57/b8/6f/57b86fe3-775c-5cbb-b614-3ec30dc08e74/886449824731.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "261110",
+                    "textColor1": "fae2b8",
+                    "textColor2": "f9dcd0",
+                    "textColor3": "cfb996",
+                    "textColor4": "ceb3aa"
+                  },
+                  "artistName": "Mimi Webb",
+                  "url": "https://music.apple.com/us/album/house-on-fire/1609153361?i=1609153365",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 140803,
+                  "releaseDate": "2022-02-18",
+                  "isAppleDigitalMaster": false,
+                  "name": "House On Fire",
+                  "isrc": "USSM12109778",
+                  "hasLyrics": true,
+                  "albumName": "House On Fire - Single",
+                  "playParams": {
+                    "id": "1609153365",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Mimi Webb, Pablo Bowman, Ines Dunn, Charlie Martin & Joe Housley"
+                }
+              },
+              {
+                "id": "1611219512",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1611219512",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/36/56/16/36561657-7052-9812-b412-36c19e73474b/mzaf_12167760052759322492.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 1500,
+                    "height": 1500,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/99/99/ad/9999ad82-4828-1254-4e11-2134461e174d/194690764974_cover.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f7eaf1",
+                    "textColor1": "3f1c2b",
+                    "textColor2": "432431",
+                    "textColor3": "634553",
+                    "textColor4": "674c58"
+                  },
+                  "artistName": "Tyga & Doja Cat",
+                  "url": "https://music.apple.com/us/album/freaky-deaky/1611219510?i=1611219512",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 215281,
+                  "releaseDate": "2022-02-25",
+                  "isAppleDigitalMaster": false,
+                  "name": "Freaky Deaky",
+                  "isrc": "USUYG1414608",
+                  "hasLyrics": true,
+                  "albumName": "Freaky Deaky - Single",
+                  "playParams": {
+                    "id": "1611219512",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Alyssa Lourdiz Cantu, Amala Dlamini, Michael Stevenson, Brandon Hamlin, Lukasz Gottwald, Mike Crook, Ryan Ogren & Suzanne Vega",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1616186939",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1616186939",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview122/v4/db/3f/47/db3f47bf-4665-6f83-cf79-94059cb69fb2/mzaf_9123346230545605100.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/00/e2/c7/00e2c71b-3b7c-d9b6-7ee5-50dc7412af42/22UMGIM29279.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "1f1f15",
+                    "textColor1": "e7bbdc",
+                    "textColor2": "d89598",
+                    "textColor3": "bf9bb4",
+                    "textColor4": "b37d7e"
+                  },
+                  "artistName": "Shawn Mendes",
+                  "url": "https://music.apple.com/us/album/when-youre-gone/1616186935?i=1616186939",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 172267,
+                  "releaseDate": "2022-03-31",
+                  "isAppleDigitalMaster": true,
+                  "name": "When You're Gone",
+                  "isrc": "USUM72204098",
+                  "hasLyrics": true,
+                  "albumName": "When You're Gone - Single",
+                  "playParams": {
+                    "id": "1616186939",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Shawn Mendes, Jonah Shy & Scott Harris"
+                }
+              },
+              {
+                "id": "1614337328",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1614337328",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/78/b4/95/78b4950f-35fc-db75-bdbc-4160f3185f9f/mzaf_8522342611911731563.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3627,
+                    "height": 3627,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/62/f2/68/62f268ef-321f-bfb3-bccc-d1b5d98e3754/22UMGIM25438.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "040513",
+                    "textColor1": "f070c4",
+                    "textColor2": "43a2e1",
+                    "textColor3": "c05ba1",
+                    "textColor4": "3683b8"
+                  },
+                  "artistName": "Coi Leray & Nicki Minaj",
+                  "url": "https://music.apple.com/us/album/blick-blick/1614337202?i=1614337328",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 178413,
+                  "releaseDate": "2022-03-18",
+                  "isAppleDigitalMaster": true,
+                  "name": "Blick Blick",
+                  "isrc": "USUM72203386",
+                  "hasLyrics": true,
+                  "albumName": "Blick Blick - Single",
+                  "playParams": {
+                    "id": "1614337328",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Coi Leray, Nicki Minaj, Lukasz Gottwald, Rocco Valdes, Ryan Ogren, Mike Crook, Randall Hammers & Asia Smith",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1613569750",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1613569750",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview122/v4/b5/87/c6/b587c646-971c-4b20-f795-5a3282ce4114/mzaf_16419497482764902441.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 4000,
+                    "height": 4000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/0e/f5/d7/0ef5d766-42df-7f2c-f6a5-bc7004754403/190296182464.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "ffffff",
+                    "textColor1": "000000",
+                    "textColor2": "5e0655",
+                    "textColor3": "333333",
+                    "textColor4": "7e3877"
+                  },
+                  "artistName": "Joel Corry, David Guetta & Bryson Tiller",
+                  "url": "https://music.apple.com/us/album/what-would-you-do/1613569404?i=1613569750",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Dance",
+                    "Music",
+                    "House"
+                  ],
+                  "durationInMillis": 174215,
+                  "releaseDate": "2022-03-18",
+                  "isAppleDigitalMaster": false,
+                  "name": "What Would You Do?",
+                  "isrc": "GBAHS2200279",
+                  "hasLyrics": true,
+                  "albumName": "What Would You Do? - Single",
+                  "playParams": {
+                    "id": "1613569750",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1
+                }
+              },
+              {
+                "id": "1586662253",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1586662253",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/0a/8c/6a/0a8c6ac9-659e-55f9-dc08-f5522e73ca26/mzaf_10708622331232675633.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/e7/bb/89/e7bb8947-38c3-8ad0-fb6e-6b90891af223/886449568475.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "884a4d",
+                    "textColor1": "fae3ce",
+                    "textColor2": "febf00",
+                    "textColor3": "e3c4b4",
+                    "textColor4": "e7a80f"
+                  },
+                  "artistName": "Lucky Daye",
+                  "url": "https://music.apple.com/us/album/over/1586662251?i=1586662253",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "R&B/Soul",
+                    "Music"
+                  ],
+                  "durationInMillis": 205276,
+                  "releaseDate": "2021-09-22",
+                  "isAppleDigitalMaster": false,
+                  "name": "Over",
+                  "isrc": "USRC12102179",
+                  "hasLyrics": true,
+                  "albumName": "Over - Single",
+                  "playParams": {
+                    "id": "1586662253",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "David Brown, Dernst Emile II, Carl Devonish, Jr., Mike “Hunnid” McGregor, Ivan Barias, Carvin Haggins, Taalib Johnson & Francis Lai",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1616261253",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1616261253",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/a6/38/f8/a638f82a-0f39-74d1-4077-89c295cd859b/mzaf_5249797436524250229.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/9b/6f/83/9b6f83ae-16b8-e873-74fb-494e4340108f/886449924967.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "b51f2b",
+                    "textColor1": "fff3a1",
+                    "textColor2": "fca059",
+                    "textColor3": "f0c889",
+                    "textColor4": "ee8650"
+                  },
+                  "artistName": "Latto & Mariah Carey",
+                  "url": "https://music.apple.com/us/album/big-energy-remix-feat-dj-khaled/1616261250?i=1616261253",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 181666,
+                  "releaseDate": "2022-03-28",
+                  "isAppleDigitalMaster": false,
+                  "name": "Big Energy (Remix) [feat. DJ Khaled]",
+                  "isrc": "USRC12200496",
+                  "hasLyrics": true,
+                  "albumName": "Big Energy (Remix) [feat. DJ Khaled] - Single",
+                  "playParams": {
+                    "id": "1616261253",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Mariah Carey, Alyssa Stephens, Vaughn Oliver, Lukasz Gottwald, Theron Thomas, Adrian Belew, Christopher Frantz, Steven Stanley, Tina Weymouth, Randall Hammers, Jaucquez Lowe, A1 Laflare & Dave Hall",
+                  "contentRating": "clean"
+                }
+              },
+              {
+                "id": "1591640885",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1591640885",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/b0/d6/0d/b0d60dfb-bee9-6cd9-2549-0ec2b7bd1848/mzaf_17985568768977172877.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/76/77/08/767708a7-ec93-3b3d-3bac-40086e5a265c/21UM1IM29634.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "141a10",
+                    "textColor1": "fcfef9",
+                    "textColor2": "fe255c",
+                    "textColor3": "cdd0ca",
+                    "textColor4": "cf224c"
+                  },
+                  "artistName": "Imagine Dragons, JID & League of Legends",
+                  "url": "https://music.apple.com/us/album/enemy-from-the-series-arcane-league-of-legends/1591640884?i=1591640885",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 173381,
+                  "releaseDate": "2021-10-28",
+                  "isAppleDigitalMaster": true,
+                  "name": "Enemy (From the series \"Arcane League of Legends\")",
+                  "isrc": "USUM72119916",
+                  "hasLyrics": true,
+                  "albumName": "Enemy (From the series \"Arcane League of Legends\") - Single",
+                  "playParams": {
+                    "id": "1591640885",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Dan Reynolds, Justin Tranter, Wayne Sermon, Ben McKee, Daniel Platzman, Robin Fredriksson, Mattias Larsson & Destin Route"
+                }
+              },
+              {
+                "id": "1582660725",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1582660725",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview115/v4/f9/3e/30/f93e30ce-5100-ab65-4b78-2b71b6009c06/mzaf_14575040342747165136.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/9f/cf/dc/9fcfdc19-7a61-3836-defb-35d817529b25/886449511440.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "286a80",
+                    "textColor1": "f9eae3",
+                    "textColor2": "fbeacc",
+                    "textColor3": "cfd0cf",
+                    "textColor4": "d1d1bc"
+                  },
+                  "artistName": "Lil Nas X",
+                  "url": "https://music.apple.com/us/album/thats-what-i-want/1582660720?i=1582660725",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 143901,
+                  "releaseDate": "2021-09-17",
+                  "isAppleDigitalMaster": false,
+                  "name": "THATS WHAT I WANT",
+                  "isrc": "USSM12105732",
+                  "hasLyrics": true,
+                  "albumName": "MONTERO",
+                  "playParams": {
+                    "id": "1582660725",
+                    "kind": "song"
+                  },
+                  "trackNumber": 4,
+                  "composerName": "Montero Hill, Omer Fedi, Blake Slatkin, Ryan Tedder & Keegan Bach",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1605027811",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1605027811",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/d8/26/38/d82638fb-45aa-7499-c5c1-43ba353b31e4/mzaf_1879488895182273923.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/bf/94/7a/bf947ab2-e9f0-5263-8a3d-d4f0ef6192d6/22UMGIM02189.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "035b91",
+                    "textColor1": "f9f5eb",
+                    "textColor2": "f9dfdb",
+                    "textColor3": "c8d6d9",
+                    "textColor4": "c8c5cc"
+                  },
+                  "artistName": "Em Beihold",
+                  "url": "https://music.apple.com/us/album/numb-little-bug/1605027263?i=1605027811",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 169238,
+                  "releaseDate": "2022-01-28",
+                  "isAppleDigitalMaster": true,
+                  "name": "Numb Little Bug",
+                  "isrc": "USUM72200626",
+                  "hasLyrics": true,
+                  "albumName": "Numb Little Bug - Single",
+                  "playParams": {
+                    "id": "1605027811",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Emily Beihold, Nick Lopez & Andrew DeCaro"
+                }
+              },
+              {
+                "id": "1607918366",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1607918366",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/5c/8d/fc/5c8dfc8e-386c-94b9-5568-5803eec02f3e/mzaf_13044269597646734758.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/5b/da/8d/5bda8d04-7f2f-4417-12a0-e039dd011152/886449800193.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "ffffff",
+                    "textColor1": "191716",
+                    "textColor2": "5b1b17",
+                    "textColor3": "474544",
+                    "textColor4": "7c4946"
+                  },
+                  "artistName": "ROSALÍA",
+                  "url": "https://music.apple.com/us/album/candy/1607918350?i=1607918366",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop Latino",
+                    "Music",
+                    "Latin",
+                    "Pop"
+                  ],
+                  "durationInMillis": 193489,
+                  "releaseDate": "2022-03-18",
+                  "isAppleDigitalMaster": false,
+                  "name": "CANDY",
+                  "isrc": "USSM12109219",
+                  "hasLyrics": true,
+                  "albumName": "MOTOMAMI",
+                  "playParams": {
+                    "id": "1607918366",
+                    "kind": "song"
+                  },
+                  "trackNumber": 2,
+                  "composerName": "ROSALÍA, Pablo Diaz-Reixa, Frank Dukes, Adam Feeney, Kaan Gunesberk, David Rodriguez, William Bevan, Lashawn Daniels, Fred Jerkins III, Rodney Jerkins & William Ray Norwood, Jr."
+                }
+              },
+              {
+                "id": "1615477888",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1615477888",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/b6/76/29/b67629a8-67e8-86d5-d84a-e22164062b44/mzaf_15167415255791773183.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music112/v4/91/a7/d8/91a7d82d-5416-2d72-014f-c62ed8a1e89c/22UMGIM27509.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "edf7f9",
+                    "textColor1": "2c1b15",
+                    "textColor2": "351a15",
+                    "textColor3": "524743",
+                    "textColor4": "5a4643"
+                  },
+                  "artistName": "Summer Walker, SZA & Cardi B",
+                  "url": "https://music.apple.com/us/album/no-love-extended-version/1615477870?i=1615477888",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "R&B/Soul",
+                    "Music"
+                  ],
+                  "durationInMillis": 276214,
+                  "releaseDate": "2022-03-25",
+                  "isAppleDigitalMaster": true,
+                  "name": "No Love (Extended Version)",
+                  "isrc": "USUM72202839",
+                  "hasLyrics": true,
+                  "albumName": "No Love (Extended Version) - Single",
+                  "playParams": {
+                    "id": "1615477888",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Summer Walker, Belcalis Almanzar, Charles “Prince Charlez” Hinshaw, Charles Jr Ocansey, Charles McAllister, Sean Garrett, SZA & Sony Anderson de Sousa Ramos",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1612719271",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1612719271",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/99/55/ff/9955ff93-c9cb-eb46-4f87-60785a4fb1ba/mzaf_12809413163359083637.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/8e/d0/e4/8ed0e4a9-bb96-e221-7440-002d2bb973cf/610012525073_cover.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "73ee17",
+                    "textColor1": "161616",
+                    "textColor2": "161616",
+                    "textColor3": "294116",
+                    "textColor4": "294116"
+                  },
+                  "artistName": "Russ",
+                  "url": "https://music.apple.com/us/album/handsomer-remix-feat-ktlyn/1612719268?i=1612719271",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music",
+                    "R&B/Soul"
+                  ],
+                  "durationInMillis": 143415,
+                  "releaseDate": "2022-03-09",
+                  "isAppleDigitalMaster": false,
+                  "name": "HANDSOMER (Remix) [feat. Ktlyn]",
+                  "isrc": "QZQAY2239696",
+                  "hasLyrics": true,
+                  "albumName": "HANDSOMER (Remix) [feat. Ktlyn] - Single",
+                  "playParams": {
+                    "id": "1612719271",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Ktlyn Raps & Russell Vitale",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1581087034",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1581087034",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview122/v4/d8/eb/6a/d8eb6aad-0d8c-8da3-446e-005cb08e5f1c/mzaf_10141041291425116909.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 4000,
+                    "height": 4000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/c5/d8/c6/c5d8c675-63e3-6632-33db-2401eabe574d/190296491412.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "350200",
+                    "textColor1": "fed400",
+                    "textColor2": "f54f35",
+                    "textColor3": "d5aa00",
+                    "textColor4": "cf402a"
+                  },
+                  "artistName": "Ed Sheeran",
+                  "url": "https://music.apple.com/us/album/shivers/1581087024?i=1581087034",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 207853,
+                  "releaseDate": "2021-09-09",
+                  "isAppleDigitalMaster": true,
+                  "name": "Shivers",
+                  "isrc": "GBAHS2100671",
+                  "hasLyrics": true,
+                  "albumName": "=",
+                  "playParams": {
+                    "id": "1581087034",
+                    "kind": "song"
+                  },
+                  "trackNumber": 2,
+                  "composerName": "Ed Sheeran, Johnny McDaid, Kal Lavelle & Steve Mac"
+                }
+              },
+              {
+                "id": "1597132449",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1597132449",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/9f/28/57/9f285723-1000-4552-c475-0aabddd8d260/mzaf_15032243671015376645.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 4000,
+                    "height": 4000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/0c/86/8d/0c868d5a-81f4-42dd-1ce2-f6569fee0585/190296332722.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "aaaaaa",
+                    "textColor1": "1b1a17",
+                    "textColor2": "1b1b1b",
+                    "textColor3": "383734",
+                    "textColor4": "373737"
+                  },
+                  "artistName": "CKay",
+                  "url": "https://music.apple.com/us/album/emiliana/1597132174?i=1597132449",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Afro-Pop",
+                    "Music",
+                    "African"
+                  ],
+                  "durationInMillis": 164848,
+                  "releaseDate": "2021-12-03",
+                  "isAppleDigitalMaster": false,
+                  "name": "Emiliana",
+                  "isrc": "ZA34K2100657",
+                  "hasLyrics": true,
+                  "albumName": "Emiliana - Single",
+                  "playParams": {
+                    "id": "1597132449",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "BMH & CKay"
+                }
+              },
+              {
+                "id": "1604944757",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1604944757",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/d5/e3/11/d5e3118f-e055-ad85-9b53-c24c48cac2a0/mzaf_11972939650851221850.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 1425,
+                    "height": 1425,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/e6/52/54/e6525474-f011-257e-04b7-12ecbae264e1/810043689519.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "9ca5ac",
+                    "textColor1": "04080a",
+                    "textColor2": "1d2126",
+                    "textColor3": "23272b",
+                    "textColor4": "363c41"
+                  },
+                  "artistName": "Gunna & Future",
+                  "url": "https://music.apple.com/us/album/pushin-p-feat-young-thug/1604944424?i=1604944757",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 136267,
+                  "releaseDate": "2022-01-07",
+                  "isAppleDigitalMaster": true,
+                  "name": "pushin P (feat. Young Thug)",
+                  "isrc": "QMCE32200039",
+                  "hasLyrics": true,
+                  "albumName": "DRIP SEASON 4EVER",
+                  "playParams": {
+                    "id": "1604944757",
+                    "kind": "song"
+                  },
+                  "trackNumber": 2,
+                  "composerName": "Jeffery Lamar Williams, Juke Wong, Nayvadius Wilburn, Sergio Kitchens & Wesley Glass",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1227451772",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1227451772",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/01/11/8b/01118b7d-8dfd-4bda-b431-3172d0a7b09a/mzaf_11749717436518009661.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 1425,
+                    "height": 1425,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music114/v4/fb/bf/6d/fbbf6d06-9a6c-9c49-c313-aed403613252/075679900180.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "242424",
+                    "textColor1": "e4e4e4",
+                    "textColor2": "cdcdcd",
+                    "textColor3": "bdbdbd",
+                    "textColor4": "ababab"
+                  },
+                  "artistName": "Jaymes Young",
+                  "url": "https://music.apple.com/us/album/infinity/1227451760?i=1227451772",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Alternative",
+                    "Music"
+                  ],
+                  "durationInMillis": 237655,
+                  "releaseDate": "2017-06-23",
+                  "isAppleDigitalMaster": true,
+                  "name": "Infinity",
+                  "isrc": "USAT21700938",
+                  "hasLyrics": true,
+                  "albumName": "Feel Something",
+                  "playParams": {
+                    "id": "1227451772",
+                    "kind": "song"
+                  },
+                  "trackNumber": 12,
+                  "composerName": "Billboard & Jaymes Young"
+                }
+              },
+              {
+                "id": "1611056166",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1611056166",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/99/f6/bd/99f6bdd9-7446-764b-5fe0-489cfb754583/mzaf_2130758385325759575.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/f4/76/d0/f476d05a-9e7f-4e88-e891-9488dabe3b5f/886449944361.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "1a1728",
+                    "textColor1": "e39c52",
+                    "textColor2": "e98f92",
+                    "textColor3": "ba8149",
+                    "textColor4": "bf777d"
+                  },
+                  "artistName": "Lil Durk",
+                  "url": "https://music.apple.com/us/album/what-happened-to-virgil-feat-gunna/1611055823?i=1611056166",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 181393,
+                  "releaseDate": "2022-03-11",
+                  "isAppleDigitalMaster": false,
+                  "name": "What Happened To Virgil (feat. Gunna)",
+                  "isrc": "USQX92200954",
+                  "hasLyrics": true,
+                  "albumName": "7220",
+                  "playParams": {
+                    "id": "1611056166",
+                    "kind": "song"
+                  },
+                  "trackNumber": 9,
+                  "composerName": "Durk Banks, Sergio Kitchens & Darrel Jackson",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1598221453",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1598221453",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/bd/b4/b9/bdb4b98f-f719-e736-2fd9-edbf2d55ae50/mzaf_6450452364553722682.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/f6/4f/19/f64f19b7-3ab4-ad2d-5a67-ca196d278b44/886449787043.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f8f8f8",
+                    "textColor1": "000000",
+                    "textColor2": "242731",
+                    "textColor3": "313131",
+                    "textColor4": "4e5058"
+                  },
+                  "artistName": "SZA",
+                  "url": "https://music.apple.com/us/album/i-hate-u/1598221271?i=1598221453",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "R&B/Soul",
+                    "Music"
+                  ],
+                  "durationInMillis": 174000,
+                  "releaseDate": "2021-12-03",
+                  "isAppleDigitalMaster": false,
+                  "name": "I Hate U",
+                  "isrc": "USRC12103605",
+                  "hasLyrics": true,
+                  "albumName": "I Hate U - Single",
+                  "playParams": {
+                    "id": "1598221453",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "SZA, Carter Lang, Robert Bisel, Cody Fayne & Dylan Patrice",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1606770075",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1606770075",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/ba/47/99/ba479934-bf11-5c81-f49e-c7a6cf810eed/mzaf_17792816694450847271.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/75/39/0b/75390bbc-2dff-f39d-e3d5-95851a98f31a/21UM1IM53248.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f1f1f1",
+                    "textColor1": "000000",
+                    "textColor2": "131313",
+                    "textColor3": "303030",
+                    "textColor4": "404040"
+                  },
+                  "artistName": "Jax Jones & MNEK",
+                  "url": "https://music.apple.com/us/album/where-did-you-go/1606770074?i=1606770075",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Dance",
+                    "Music"
+                  ],
+                  "durationInMillis": 177689,
+                  "releaseDate": "2022-02-04",
+                  "isAppleDigitalMaster": true,
+                  "name": "Where Did You Go?",
+                  "isrc": "GBUM72108841",
+                  "hasLyrics": true,
+                  "albumName": "Where Did You Go? - Single",
+                  "playParams": {
+                    "id": "1606770075",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Mark Ralph, Siba, Timucin Lam, Uzoechi Emenike & Wayne Hector"
+                }
+              },
+              {
+                "id": "1614925321",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1614925321",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/c1/ba/c1/c1bac15e-c5e6-454b-fcdf-c868c5244853/mzaf_1515460887422021502.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/87/2b/df/872bdf7c-193a-44fa-e254-5946a73f9d8c/22UMGIM29244.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "cbe4e1",
+                    "textColor1": "0d2a3c",
+                    "textColor2": "0f3347",
+                    "textColor3": "334f5d",
+                    "textColor4": "345765"
+                  },
+                  "artistName": "J Balvin & Ed Sheeran",
+                  "url": "https://music.apple.com/us/album/forever-my-love/1614925309?i=1614925321",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Urbano latino",
+                    "Music",
+                    "Latin"
+                  ],
+                  "durationInMillis": 190601,
+                  "releaseDate": "2022-03-25",
+                  "isAppleDigitalMaster": true,
+                  "name": "Forever My Love",
+                  "isrc": "QZM5U2200344",
+                  "hasLyrics": true,
+                  "albumName": "Sigue/Forever My Love - Single",
+                  "playParams": {
+                    "id": "1614925321",
+                    "kind": "song"
+                  },
+                  "trackNumber": 2,
+                  "composerName": "J Balvin, Ed Sheeran, Michael Brun, Justin Quiles & Keytin"
+                }
+              },
+              {
+                "id": "1591302173",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1591302173",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/26/1f/a6/261fa6ee-5c94-66b0-082c-e54806a7def6/mzaf_1023143117711369263.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 4000,
+                    "height": 4000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/b5/cc/41/b5cc41e2-e100-fd15-a179-08b928c10c88/190296388019.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "e0d4c6",
+                    "textColor1": "091014",
+                    "textColor2": "0b1013",
+                    "textColor3": "343737",
+                    "textColor4": "363737"
+                  },
+                  "artistName": "John Summit",
+                  "url": "https://music.apple.com/us/album/human-feat-echoes/1591302000?i=1591302173",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Dance",
+                    "Music"
+                  ],
+                  "durationInMillis": 219048,
+                  "releaseDate": "2021-11-24",
+                  "isAppleDigitalMaster": false,
+                  "name": "Human (feat. Echoes)",
+                  "isrc": "GBAYE2101411",
+                  "hasLyrics": true,
+                  "albumName": "Human (feat. Echoes) - Single",
+                  "playParams": {
+                    "id": "1591302173",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Angel Z, Freek Geuze, John Schuster, Oliver Jacobs, Paul Clarke & Phillip Jacobs"
+                }
+              },
+              {
+                "id": "1592774398",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1592774398",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/46/ae/a2/46aea269-4890-093c-e7c8-137e844d6584/mzaf_8873314157668988966.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 1425,
+                    "height": 1425,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/6b/3b/fc/6b3bfc34-cdce-b3ef-db0f-caa4b760dd0b/075679764195.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "000000",
+                    "textColor1": "feffff",
+                    "textColor2": "c2c8c7",
+                    "textColor3": "cbcbcb",
+                    "textColor4": "9ba09f"
+                  },
+                  "artistName": "Kodak Black",
+                  "url": "https://music.apple.com/us/album/super-gremlin/1592774394?i=1592774398",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Hip-Hop/Rap",
+                    "Music"
+                  ],
+                  "durationInMillis": 200548,
+                  "releaseDate": "2022-02-10",
+                  "isAppleDigitalMaster": true,
+                  "name": "Super Gremlin",
+                  "isrc": "USAT22107295",
+                  "hasLyrics": true,
+                  "albumName": "Sniper Gang Presents Syko Bob & Snapkatt: Nightmare Babies",
+                  "playParams": {
+                    "id": "1592774398",
+                    "kind": "song"
+                  },
+                  "trackNumber": 4,
+                  "composerName": "Bill K. Kapri, Jacob Canady & Maik Alexander Timmermann",
+                  "contentRating": "explicit"
+                }
+              },
+              {
+                "id": "1610192494",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1610192494",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/ae/46/7f/ae467f19-98f4-efd7-8a0b-fd5818417d73/mzaf_9600752446927552100.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music116/v4/1d/04/18/1d04187c-76f4-9a83-8006-d09fafb7b02b/054391906199.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "201e03",
+                    "textColor1": "e4e5b5",
+                    "textColor2": "bae0c4",
+                    "textColor3": "bdbe91",
+                    "textColor4": "9bba9d"
+                  },
+                  "artistName": "Omah Lay & Justin Bieber",
+                  "url": "https://music.apple.com/us/album/attention/1610192492?i=1610192494",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "R&B/Soul",
+                    "Music"
+                  ],
+                  "durationInMillis": 180563,
+                  "releaseDate": "2022-03-03",
+                  "isAppleDigitalMaster": true,
+                  "name": "Attention",
+                  "isrc": "USWB12200242",
+                  "hasLyrics": true,
+                  "albumName": "Attention - Single",
+                  "playParams": {
+                    "id": "1610192494",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "editorialNotes": {
+                    "short": "A powerhouse collab drops at the crossroads of Afrobeats and pop."
+                  },
+                  "composerName": "Bernard Harvey, Felisha King, Justin Bieber, Stanley Omah Didia & Vincent van den Ende"
+                }
+              },
+              {
+                "id": "1611645052",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1611645052",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/66/3a/33/663a337e-e4e1-6bd3-ef0e-55ca3c54b430/mzaf_15392207735980622296.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/b3/cb/0e/b3cb0e55-1998-5193-573e-135e4c92d037/886449967124.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "0c1b16",
+                    "textColor1": "dbc1ac",
+                    "textColor2": "d1b3a1",
+                    "textColor3": "b1a08e",
+                    "textColor4": "a99485"
+                  },
+                  "artistName": "Labrinth & Zendaya",
+                  "url": "https://music.apple.com/us/album/im-tired-from-euphoria-an-original-hbo-series/1611645050?i=1611645052",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 187944,
+                  "releaseDate": "2022-03-04",
+                  "isAppleDigitalMaster": false,
+                  "name": "I'm Tired (From \"Euphoria\" An Original HBO Series)",
+                  "isrc": "USQX92200588",
+                  "hasLyrics": true,
+                  "albumName": "I'm Tired (From \"Euphoria\" An Original HBO Series) - Single",
+                  "playParams": {
+                    "id": "1611645052",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Labrinth"
+                }
+              },
+              {
+                "id": "1607400982",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1607400982",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview116/v4/01/0a/65/010a658e-b01f-9076-e230-ea87d3882101/mzaf_15437112953829988947.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/f4/ea/ce/f4eace1c-fc05-dca3-b9a4-584699346fc5/dj.atfecqzn.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "1a121a",
+                    "textColor1": "088dff",
+                    "textColor2": "ff363e",
+                    "textColor3": "0c74d1",
+                    "textColor4": "d12e37"
+                  },
+                  "artistName": "Diplo & Miguel",
+                  "url": "https://music.apple.com/us/album/dont-forget-my-love/1607400716?i=1607400982",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Dance",
+                    "Music"
+                  ],
+                  "durationInMillis": 199091,
+                  "releaseDate": "2022-02-11",
+                  "isAppleDigitalMaster": false,
+                  "name": "Don't Forget My Love",
+                  "isrc": "USZ4V2200009",
+                  "hasLyrics": true,
+                  "albumName": "Diplo",
+                  "playParams": {
+                    "id": "1607400982",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Thomas Wesley Pentz, Miguel Pimentel & Maximilian Jaeger"
+                }
+              },
+              {
+                "id": "1594677760",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1594677760",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview122/v4/b3/5e/8f/b35e8f5f-1632-24da-a843-9720412d1be5/mzaf_18388837828824793637.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/94/4d/9a/944d9a8d-0549-f537-5706-5b083bd84a7d/21UM1IM38949.rgb.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "081828",
+                    "textColor1": "fdde45",
+                    "textColor2": "cbe379",
+                    "textColor3": "ccb63f",
+                    "textColor4": "a4bb69"
+                  },
+                  "artistName": "Carolina Gaitán - La Gaita, Mauro Castillo, Adassa, Rhenzy Feliz, Diane Guerrero, Stephanie Beatriz & Encanto - Cast",
+                  "url": "https://music.apple.com/us/album/we-dont-talk-about-bruno/1594677532?i=1594677760",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Soundtrack",
+                    "Music"
+                  ],
+                  "durationInMillis": 216120,
+                  "releaseDate": "2021-11-19",
+                  "isAppleDigitalMaster": true,
+                  "name": "We Don't Talk About Bruno",
+                  "isrc": "USWD12112915",
+                  "hasLyrics": true,
+                  "albumName": "Encanto (Original Motion Picture Soundtrack)",
+                  "playParams": {
+                    "id": "1594677760",
+                    "kind": "song"
+                  },
+                  "trackNumber": 4,
+                  "composerName": "Lin-Manuel Miranda"
+                }
+              },
+              {
+                "id": "1609135208",
+                "type": "songs",
+                "href": "/v1/catalog/us/songs/1609135208",
+                "attributes": {
+                  "previews": [
+                    {
+                      "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview126/v4/12/01/90/120190d6-fead-f50b-2eb6-7f280f43b001/mzaf_13748076138039923036.plus.aac.p.m4a"
+                    }
+                  ],
+                  "artwork": {
+                    "width": 3000,
+                    "height": 3000,
+                    "url": "https://is1-ssl.mzstatic.com/image/thumb/Music126/v4/b9/6e/d3/b96ed3cc-0246-d518-9235-d80d96d6512e/886449914494.jpg/{w}x{h}bb.jpg",
+                    "bgColor": "f3f4ec",
+                    "textColor1": "050506",
+                    "textColor2": "181818",
+                    "textColor3": "343534",
+                    "textColor4": "444442"
+                  },
+                  "artistName": "Dove Cameron",
+                  "url": "https://music.apple.com/us/album/boyfriend/1609135206?i=1609135208",
+                  "discNumber": 1,
+                  "genreNames": [
+                    "Pop",
+                    "Music"
+                  ],
+                  "durationInMillis": 153000,
+                  "releaseDate": "2022-02-11",
+                  "isAppleDigitalMaster": false,
+                  "name": "Boyfriend",
+                  "isrc": "USQX92200693",
+                  "hasLyrics": true,
+                  "albumName": "Boyfriend - Single",
+                  "playParams": {
+                    "id": "1609135208",
+                    "kind": "song"
+                  },
+                  "trackNumber": 1,
+                  "composerName": "Dove Cameron, Evan Blair, Delacey & Skyler Stonestreet",
+                  "contentRating": "explicit"
+                }
+              }
+            ]
+          },
+          "curator": {
+            "href": "/v1/catalog/us/playlists/pl.f4d106fed2bd41149aaacabb233eb5eb/curator",
+            "data": [
+              {
+                "id": "1526756058",
+                "type": "apple-curators",
+                "href": "/v1/catalog/us/apple-curators/1526756058"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }

--- a/Tests/AmuseKitTests/DataModels/Catalog/catalog_songs.json
+++ b/Tests/AmuseKitTests/DataModels/Catalog/catalog_songs.json
@@ -1,0 +1,133 @@
+{
+    "data": [
+      {
+        "id": "1560735548",
+        "type": "songs",
+        "href": "/v1/catalog/us/songs/1560735548",
+        "attributes": {
+          "previews": [
+            {
+              "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/af/22/53/af225371-463f-d244-0e5c-f3e4449ca160/mzaf_615547142465987226.plus.aac.p.m4a"
+            }
+          ],
+          "artwork": {
+            "width": 3000,
+            "height": 3000,
+            "url": "https://is1-ssl.mzstatic.com/image/thumb/Music125/v4/33/fd/32/33fd32b1-0e43-9b4a-8ed6-19643f23544e/21UMGIM26092.rgb.jpg/{w}x{h}bb.jpg",
+            "bgColor": "675f9a",
+            "textColor1": "f3f6fb",
+            "textColor2": "fbeaf0",
+            "textColor3": "d7d8e8",
+            "textColor4": "decedf"
+          },
+          "artistName": "Olivia Rodrigo",
+          "url": "https://music.apple.com/us/album/deja-vu/1560735414?i=1560735548",
+          "discNumber": 1,
+          "genreNames": [
+            "Pop",
+            "Music"
+          ],
+          "durationInMillis": 215508,
+          "releaseDate": "2021-04-01",
+          "isAppleDigitalMaster": true,
+          "name": "deja vu",
+          "isrc": "USUG12101240",
+          "hasLyrics": true,
+          "albumName": "SOUR",
+          "playParams": {
+            "id": "1560735548",
+            "kind": "song"
+          },
+          "trackNumber": 5,
+          "composerName": "Olivia Rodrigo & Daniel Nigro",
+          "contentRating": "explicit"
+        },
+        "relationships": {
+          "albums": {
+            "href": "/v1/catalog/us/songs/1560735548/albums",
+            "data": [
+              {
+                "id": "1560735414",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1560735414"
+              }
+            ]
+          },
+          "artists": {
+            "href": "/v1/catalog/us/songs/1560735548/artists",
+            "data": [
+              {
+                "id": "979458609",
+                "type": "artists",
+                "href": "/v1/catalog/us/artists/979458609"
+              }
+            ]
+          }
+        }
+      },
+      {
+        "id": "1572278914",
+        "type": "songs",
+        "href": "/v1/catalog/us/songs/1572278914",
+        "attributes": {
+          "previews": [
+            {
+              "url": "https://audio-ssl.itunes.apple.com/itunes-itms8-assets/AudioPreview125/v4/38/64/27/3864275c-3ee2-4e25-540b-a6dcaa78c142/mzaf_1359480979331484031.plus.aac.p.m4a"
+            }
+          ],
+          "artwork": {
+            "width": 3000,
+            "height": 3000,
+            "url": "https://is1-ssl.mzstatic.com/image/thumb/Music115/v4/03/fb/9e/03fb9e9c-43bb-2bfd-cccc-920a91affd12/21UMGIM51898.rgb.jpg/{w}x{h}bb.jpg",
+            "bgColor": "000300",
+            "textColor1": "a5d961",
+            "textColor2": "99d888",
+            "textColor3": "84ae4e",
+            "textColor4": "7aad6d"
+          },
+          "artistName": "Brandee Younger",
+          "url": "https://music.apple.com/us/album/reclamation/1572278902?i=1572278914",
+          "discNumber": 1,
+          "genreNames": [
+            "Jazz",
+            "Music"
+          ],
+          "durationInMillis": 402196,
+          "releaseDate": "2021-07-22",
+          "isAppleDigitalMaster": true,
+          "name": "Reclamation",
+          "isrc": "USUM72104683",
+          "hasLyrics": false,
+          "albumName": "Somewhere Different",
+          "playParams": {
+            "id": "1572278914",
+            "kind": "song"
+          },
+          "trackNumber": 1,
+          "composerName": "Brandee Younger"
+        },
+        "relationships": {
+          "albums": {
+            "href": "/v1/catalog/us/songs/1572278914/albums",
+            "data": [
+              {
+                "id": "1572278902",
+                "type": "albums",
+                "href": "/v1/catalog/us/albums/1572278902"
+              }
+            ]
+          },
+          "artists": {
+            "href": "/v1/catalog/us/songs/1572278914/artists",
+            "data": [
+              {
+                "id": "327193278",
+                "type": "artists",
+                "href": "/v1/catalog/us/artists/327193278"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }

--- a/Tests/AmuseKitTests/Networking/DataProviderTests.swift
+++ b/Tests/AmuseKitTests/Networking/DataProviderTests.swift
@@ -17,6 +17,89 @@ final class DataProviderTests: XCTestCase {
     override func tearDown() {
         tasks = []
     }
+    
+    // MARK: - Catalog Methods
+    
+    func testCatalogAlbums() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_albums")
+        try mock.catalog(.albums, ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+    
+    func testCatalogArtists() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_artists")
+        try mock.catalog(.artists, ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+    
+    func testCatalogMusicVideos() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_music-videos")
+        try mock.catalog(.musicVideos, ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { response in
+                print(response)
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+    
+    func testCatalogPlaylists() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_playlists")
+        try mock.catalog(.playlists, ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+    
+    func testCatalogSongs() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_songs")
+        try mock.catalog(.songs, ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
 
     func testCatalogSearch() throws {
         let completionExpectation = XCTestExpectation(description: "completion should be called")
@@ -38,127 +121,13 @@ final class DataProviderTests: XCTestCase {
         wait(for: [completionExpectation, valueExpectation], timeout: timeout)
     }
     
-    func testCatalogPlaylists() throws {
-        let completionExpectation = XCTestExpectation(description: "completion should be called")
-        let valueExpectation = XCTestExpectation(description: "value callback should be called")
-        let mock = mockDataProvider(resourceName: "catalog_playlists")
-        try mock.catalogPlaylists(ids: ["123", "456", "789"])
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { _ in
-                completionExpectation.fulfill()
-            }, receiveValue: { value in
-                XCTAssertNotNil(value.data)
-                valueExpectation.fulfill()
-            }).store(in: &tasks)
-
-        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
-    }
-    
-    func testCatalogAlbums() throws {
-        let completionExpectation = XCTestExpectation(description: "completion should be called")
-        let valueExpectation = XCTestExpectation(description: "value callback should be called")
-        let mock = mockDataProvider(resourceName: "catalog_albums")
-        try mock.catalogAlbums(ids: ["123", "456", "789"])
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { _ in
-                completionExpectation.fulfill()
-            }, receiveValue: { value in
-                XCTAssertNotNil(value.data)
-                valueExpectation.fulfill()
-            }).store(in: &tasks)
-
-        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
-    }
-    
-    func testCatalogArtists() throws {
-        let completionExpectation = XCTestExpectation(description: "completion should be called")
-        let valueExpectation = XCTestExpectation(description: "value callback should be called")
-        let mock = mockDataProvider(resourceName: "catalog_artists")
-        try mock.catalogArtists(ids: ["123", "456", "789"])
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { _ in
-                completionExpectation.fulfill()
-            }, receiveValue: { value in
-                XCTAssertNotNil(value.data)
-                valueExpectation.fulfill()
-            }).store(in: &tasks)
-
-        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
-    }
-    
-    func testCatalogSongs() throws {
-        let completionExpectation = XCTestExpectation(description: "completion should be called")
-        let valueExpectation = XCTestExpectation(description: "value callback should be called")
-        let mock = mockDataProvider(resourceName: "catalog_songs")
-        try mock.catalogSongs(ids: ["123", "456", "789"])
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { _ in
-                completionExpectation.fulfill()
-            }, receiveValue: { value in
-                XCTAssertNotNil(value.data)
-                valueExpectation.fulfill()
-            }).store(in: &tasks)
-
-        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
-    }
-    
-    func testCatalogMusicVideos() throws {
-        let completionExpectation = XCTestExpectation(description: "completion should be called")
-        let valueExpectation = XCTestExpectation(description: "value callback should be called")
-        let mock = mockDataProvider(resourceName: "catalog_music-videos")
-        try mock.catalogMusicVideos(ids: ["123", "456", "789"])
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { response in
-                print(response)
-                completionExpectation.fulfill()
-            }, receiveValue: { value in
-                XCTAssertNotNil(value.data)
-                valueExpectation.fulfill()
-            }).store(in: &tasks)
-
-        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
-    }
-
-    func testLibrarySearch() throws {
-        let completionExpectation = XCTestExpectation(description: "completion should be called")
-        let valueExpectation = XCTestExpectation(description: "value callback should be called")
-        let mock = mockDataProvider(resourceName: "library_search")
-        try mock.librarySearch(searchTerm: "")
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { _ in
-                completionExpectation.fulfill()
-            }, receiveValue: { value in
-                XCTAssertNotNil(value.results?.playlists)
-                XCTAssertNotNil(value.results?.albums)
-                XCTAssertNotNil(value.results?.artists)
-                XCTAssertNotNil(value.results?.songs)
-                valueExpectation.fulfill()
-            }).store(in: &tasks)
-
-        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
-    }
-
-    func testLibraryPlaylists() throws {
-        let completionExpectation = XCTestExpectation(description: "completion should be called")
-        let valueExpectation = XCTestExpectation(description: "value callback should be called")
-        let mock = mockDataProvider(resourceName: "library_playlists")
-        try mock.libraryPlaylists()
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { _ in
-                completionExpectation.fulfill()
-            }, receiveValue: { value in
-                XCTAssertNotNil(value.data)
-                valueExpectation.fulfill()
-            }).store(in: &tasks)
-
-        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
-    }
+    // MARK: Library Methods
     
     func testLibraryAlbums() throws {
         let completionExpectation = XCTestExpectation(description: "completion should be called")
         let valueExpectation = XCTestExpectation(description: "value callback should be called")
         let mock = mockDataProvider(resourceName: "library_albums")
-        try mock.libraryAlbums()
+        try mock.library(.albums)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { _ in
                 completionExpectation.fulfill()
@@ -174,7 +143,7 @@ final class DataProviderTests: XCTestCase {
         let completionExpectation = XCTestExpectation(description: "completion should be called")
         let valueExpectation = XCTestExpectation(description: "value callback should be called")
         let mock = mockDataProvider(resourceName: "library_artists")
-        try mock.libraryArtists()
+        try mock.library(.artists)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { _ in
                 completionExpectation.fulfill()
@@ -185,12 +154,12 @@ final class DataProviderTests: XCTestCase {
 
         wait(for: [completionExpectation, valueExpectation], timeout: timeout)
     }
-
-    func testLibrarySongs() throws {
+    
+    func testLibraryPlaylists() throws {
         let completionExpectation = XCTestExpectation(description: "completion should be called")
         let valueExpectation = XCTestExpectation(description: "value callback should be called")
-        let mock = mockDataProvider(resourceName: "library_songs")
-        try mock.librarySongs()
+        let mock = mockDataProvider(resourceName: "library_playlists")
+        try mock.library(.playlists)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { _ in
                 completionExpectation.fulfill()
@@ -206,13 +175,49 @@ final class DataProviderTests: XCTestCase {
         let completionExpectation = XCTestExpectation(description: "completion should be called")
         let valueExpectation = XCTestExpectation(description: "value callback should be called")
         let mock = mockDataProvider(resourceName: "library_music-videos")
-        try mock.libraryMusicVideos()
+        try mock.library(.musicVideos)
             .receive(on: DispatchQueue.main)
             .sink(receiveCompletion: { error in
                 print(error)
                 completionExpectation.fulfill()
             }, receiveValue: { value in
                 XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+
+
+    func testLibrarySongs() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "library_songs")
+        try mock.library(.songs)
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+    
+    func testLibrarySearch() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "library_search")
+        try mock.librarySearch(searchTerm: "")
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.results?.playlists)
+                XCTAssertNotNil(value.results?.albums)
+                XCTAssertNotNil(value.results?.artists)
+                XCTAssertNotNil(value.results?.songs)
                 valueExpectation.fulfill()
             }).store(in: &tasks)
 
@@ -232,18 +237,20 @@ final class DataProviderTests: XCTestCase {
     }
 
     static var allTests = [
-        ("testCatalogSearch", testCatalogSearch),
-        ("testCatalogPlaylists", testCatalogPlaylists),
+        // Catalog
         ("testCatalogAlbums", testCatalogAlbums),
         ("testCatalogArtists", testCatalogArtists),
-        ("testCatalogSongs", testCatalogSongs),
         ("testCatalogMusicVideos", testCatalogMusicVideos),
-        ("testLibrarySearch", testLibrarySearch),
-        ("testLibraryPlaylists", testLibraryPlaylists),
+        ("testCatalogPlaylists", testCatalogPlaylists),
+        ("testCatalogSongs", testCatalogSongs),
+        ("testCatalogSearch", testCatalogSearch),
+        // Library
         ("testLibraryAlbums", testLibraryAlbums),
         ("testLibraryArtists", testLibraryArtists),
+        ("testLibraryMusicVideos", testLibraryMusicVideos),
+        ("testLibraryPlaylists", testLibraryPlaylists),
         ("testLibrarySongs", testLibrarySongs),
-        ("testLibraryMusicVideos", testLibraryMusicVideos)
+        ("testLibrarySearch", testLibrarySearch)
     ]
 }
 

--- a/Tests/AmuseKitTests/Networking/DataProviderTests.swift
+++ b/Tests/AmuseKitTests/Networking/DataProviderTests.swift
@@ -37,6 +37,87 @@ final class DataProviderTests: XCTestCase {
 
         wait(for: [completionExpectation, valueExpectation], timeout: timeout)
     }
+    
+    func testCatalogPlaylists() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_playlists")
+        try mock.catalogPlaylists(ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+    
+    func testCatalogAlbums() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_albums")
+        try mock.catalogAlbums(ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+    
+    func testCatalogArtists() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_artists")
+        try mock.catalogArtists(ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+    
+    func testCatalogSongs() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_songs")
+        try mock.catalogSongs(ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { _ in
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
+    
+    func testCatalogMusicVideos() throws {
+        let completionExpectation = XCTestExpectation(description: "completion should be called")
+        let valueExpectation = XCTestExpectation(description: "value callback should be called")
+        let mock = mockDataProvider(resourceName: "catalog_music-videos")
+        try mock.catalogMusicVideos(ids: ["123", "456", "789"])
+            .receive(on: DispatchQueue.main)
+            .sink(receiveCompletion: { response in
+                print(response)
+                completionExpectation.fulfill()
+            }, receiveValue: { value in
+                XCTAssertNotNil(value.data)
+                valueExpectation.fulfill()
+            }).store(in: &tasks)
+
+        wait(for: [completionExpectation, valueExpectation], timeout: timeout)
+    }
 
     func testLibrarySearch() throws {
         let completionExpectation = XCTestExpectation(description: "completion should be called")
@@ -152,6 +233,11 @@ final class DataProviderTests: XCTestCase {
 
     static var allTests = [
         ("testCatalogSearch", testCatalogSearch),
+        ("testCatalogPlaylists", testCatalogPlaylists),
+        ("testCatalogAlbums", testCatalogAlbums),
+        ("testCatalogArtists", testCatalogArtists),
+        ("testCatalogSongs", testCatalogSongs),
+        ("testCatalogMusicVideos", testCatalogMusicVideos),
         ("testLibrarySearch", testLibrarySearch),
         ("testLibraryPlaylists", testLibraryPlaylists),
         ("testLibraryAlbums", testLibraryAlbums),

--- a/Tests/AmuseKitTests/XCTestManifests.swift
+++ b/Tests/AmuseKitTests/XCTestManifests.swift
@@ -4,6 +4,7 @@ import XCTest
 public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(DataProviderTests.allTests),
+        testCase(RouterTests.allTests)
     ]
 }
 #endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,6 @@
 import XCTest
-import AmuseTests
+import AmuseKitTests
 
 var tests = [XCTestCaseEntry]()
-tests += DataProviderTests.allTests()
+tests += AmuseKitTests.allTests()
 XCTMain(tests)


### PR DESCRIPTION
- [Bump dependencies version](https://github.com/jjotaum/AmuseKit/commit/34a33990c272de3b915d7af8ed120e77aa4c7987)
- [bump swift-tools-version to 5.6](https://github.com/jjotaum/AmuseKit/commit/85986cf3284d14b35e9ca74ca1cf4f68c7feac85)
- [Update test manifests and linux main files to include recente unit tests](https://github.com/jjotaum/AmuseKit/commit/ee2fe0990b790fc5a32a502e5d6c8856d82ea963)
- [Add support to retrieve catalog resources](https://github.com/jjotaum/AmuseKit/commit/c10c7d85805b53c221d4a393107d6066246a1c40)
- [Refactor library & catalog requests to use a more intuitive convention and follow DRY principle, Update Readme file to reflect latest changes](https://github.com/jjotaum/AmuseKit/commit/dce15d692d3d5291c4751ebd45336614a95b6680)